### PR TITLE
fix: windows homedir

### DIFF
--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -115,8 +115,8 @@ export class TestSession {
     transferExistingAuthToEnv();
 
     // Set the homedir used by this test, on the TestSession and the process
-    // TODO: does this work on Windows?
-    process.env.HOME = this.homeDir = env.getString('TESTKIT_HOMEDIR', this.dir);
+    process.env.USERPROFILE = process.env.HOME = this.homeDir = env.getString('TESTKIT_HOMEDIR', this.dir);
+
     process.env.SFDX_USE_GENERIC_UNIX_KEYCHAIN = 'true';
     testkitHubAuth(this.homeDir);
     // Run all setup commands

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -52,6 +52,7 @@ describe('TestSession', () => {
       expect(session.project).to.equal(undefined);
       expect(session.setup).to.equal(undefined);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should create a session with specific dir', () => {
@@ -67,6 +68,7 @@ describe('TestSession', () => {
       expect(session.project).to.equal(undefined);
       expect(session.setup).to.equal(undefined);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should create a session with specific dir and homedir from env', () => {
@@ -88,6 +90,7 @@ describe('TestSession', () => {
       expect(session.project).to.equal(undefined);
       expect(session.setup).to.equal(undefined);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should create a session with a project', () => {
@@ -111,6 +114,7 @@ describe('TestSession', () => {
       expect(stubCwdStub.firstCall.args[0]).to.equal(session.project?.dir);
       expect(session.setup).to.equal(undefined);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should use an existing project', () => {
@@ -140,6 +144,7 @@ describe('TestSession', () => {
       expect(stubCwdStub.firstCall.args[0]).to.equal(projectDir);
       expect(session.setup).to.equal(undefined);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should create a session with setup commands', () => {
@@ -161,6 +166,7 @@ describe('TestSession', () => {
       expect(session.setup).to.deep.equal([execRv]);
       expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
     it('should create a session with org creation setup commands', () => {
@@ -183,6 +189,8 @@ describe('TestSession', () => {
       expect(session.setup).to.deep.equal([execRv]);
       expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
+
       // @ts-ignore session.orgs is private
       expect(session.orgs).to.deep.equal([username]);
     });
@@ -214,6 +222,8 @@ describe('TestSession', () => {
       expect(session.setup).to.deep.equal([{ result: { username: overriddenUsername } }]);
       expect(execStub.called).to.equal(false);
       expect(process.env.HOME).to.equal(session.homeDir);
+      expect(process.env.USERPROFILE).to.equal(session.homeDir);
+
       // @ts-ignore session.orgs is private
       expect(session.orgs).to.deep.equal([]);
     });


### PR DESCRIPTION
related to and needed by @W-8721307@
sets both process.env.HOME (posix) and process.env.USERPROFILE (windows).

homedir wasn't being moved in windows
single-nut runs fine in circle
parallel nuts fail after the first one deletes the authinfo files that unfinished runs are relying on