### PR TITLE
feat: specify auth strategy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 
 export * from './genUniqueString';
 export * from './execCmd';
+export { prepareForAuthUrl, prepareForJwt } from './hubAuth';
 export * from './testProject';
 export * from './testSession';
 export { Duration } from '@salesforce/kit';


### PR DESCRIPTION
Allows use to specify the auth strategy when creating a test session. If no strategy is provided, it defaults to the existing behavior (determining the strategy based on the env vars)

This is required to write NUTs for plugin-auth, where we don't want test session to do the auth'ing for us

@W-8856588@