### PR TITLE
fix: throw if sfdx is not found

### DIFF
--- a/src/testProject.ts
+++ b/src/testProject.ts
@@ -70,6 +70,10 @@ export class TestProject {
     }
     // Create a new project using the command.
     else {
+      // verify sfdx is found
+      if (!shell.which('sfdx')) {
+        throw new Error('sfdx executable not found for creating a project using force:project:create command');
+      }
       const name = options.name || genUniqueString('project_%s');
       const rv = shell.exec(`sfdx force:project:create -n ${name} -d ${destDir}`, { silent: true });
       if (rv.code !== 0) {

--- a/test/unit/testProject.test.ts
+++ b/test/unit/testProject.test.ts
@@ -65,7 +65,7 @@ describe('TestProject', () => {
     expect(execStub.firstCall.args[1]).to.deep.equal({ cwd: destinationDir, silent: true });
   });
 
-  it('should error if git not found', () => {
+  it('should error if git clone fails', () => {
     const gitClone = 'https://github.com/testProj.git';
     const shellString = new ShellString('');
     shellString.code = 1;
@@ -80,7 +80,7 @@ describe('TestProject', () => {
     }
   });
 
-  it('should error if git clone fails', () => {
+  it('should error if git not found', () => {
     const gitClone = 'https://github.com/testProj.git';
     stubMethod(sandbox, shelljs, 'which').returns(null);
     try {
@@ -125,6 +125,20 @@ describe('TestProject', () => {
       assert(false, 'TestProject should throw');
     } catch (err: unknown) {
       expect((err as Error).message).to.equal(`force:project:create failed with error:\n${shellString.stderr}`);
+    }
+  });
+
+  it('should error if sfdx not found', () => {
+    stubMethod(sandbox, shelljs, 'which').returns(null);
+    const name = 'MyTestProject';
+    const destinationDir = pathJoin('foo', 'bar');
+    try {
+      new TestProject({ name, destinationDir });
+      assert(false, 'TestProject should throw');
+    } catch (err: unknown) {
+      expect((err as Error).message).to.equal(
+        'sfdx executable not found for creating a project using force:project:create command'
+      );
     }
   });
 


### PR DESCRIPTION
When sfdx is not installed and a TestSession tries to create a test project using the `force:project:create` command it will fail with (sometimes) an error that is not very intuitive.  This adds some code that will throw an error that is more helpful.

@W-8996057@