### PR TITLE
Sh/generate samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 # Description
 
-**This package is in heavy development. The APIs exposed from this package are incomplete and will change frequently.**
-
 The @salesforce/cli-plugins-testkit library provides test utilities to assist Salesforce CLI plug-in authors with writing NUTs (non-unit-tests), like integration, smoke, and e2e style testing. For example, you could write tests to ensure your plugin commands execute properly using an isolated Salesforce project, scratch org, and different Salesforce CLI executables.
 
 # Usage
@@ -31,9 +29,19 @@ Using a different file extension will help separate your unit tests from your NU
 
 **See [Samples](./SAMPLES.md) doc for many testkit usecases and sample code**
 
+# Example NUTs
+
+Here are some public github repos for plugins that use this library for NUTs:
+[@salesforce/plugin-alias NUT](https://github.com/salesforcecli/plugin-alias/blob/main/test/commands/alias/set.nut.ts)
+[@salesforce/plugin-auth NUT](https://github.com/salesforcecli/plugin-auth/blob/main/test/commands/auth/list.nut.ts)
+[@salesforce/plugin-config NUT](https://github.com/salesforcecli/plugin-config/blob/main/test/commands/config/list.nut.ts)
+[@salesforce/plugin-data NUT](https://github.com/salesforcecli/data/blob/main/packages/plugin-data/test/commands/force/data/tree/dataTree.nut.ts)
+[@salesforce/plugin-org NUT](https://github.com/salesforcecli/plugin-org/blob/main/test/nut/commands/force/org/org.nut.ts)
+[@salesforce/plugin-user NUT](https://github.com/salesforcecli/plugin-user/blob/main/test/allCommands.nut.ts)
+
 ## Running Commands
 
-Running oclif commands locally is as simple as running against the local `bin/run` file.
+Although oclif provides a way to run commands locally using the local `bin/run` file...
 
 ```typescript
 import { exec } from 'shelljs';
@@ -41,18 +49,16 @@ const result = exec('./bin/run mycommand --myflag --json');
 console.log(JSON.parse(result.stdout));
 ```
 
-However, that doesn't provide flexibility to target different CLI executables in Continuos Integration (CI). For example, you may want to run NUTs against the newly published version of your plugin against the latest-rc of the Salesforce CLI to make sure everything still works as expected.
+...that doesn't provide flexibility to target different CLI executables in Continuous Integration (CI). For example, you may want to run NUTs against the newly published version of your plugin using the latest-rc of the Salesforce CLI to make sure everything still works as expected.
 
-The testkit provides `execCmd` which makes the executable configurable as well as builtin json parsing.
+The testkit provides `execCmd` which uses the `TESTKIT_EXECUTABLE_PATH` environment variable to run a plugin command, in addition to other useful builtin utilties such as json parsing, return type casting (for TypeScript) and command execution timing.
 
 ```typescript
 import { execCmd } from '@salesforce/cli-plugins-testkit';
 
-const result = execCmd('mycommand --myflag --json');
-console.log(result.jsonOutput);
+const result = execCmd<MyReturntype>('mycommand --myflag --json').jsonOutput;
+expect(result.name).to.equal('expectedName');
 ```
-
-The executable can then be configured in CI using the `TESTKIT_EXECUTABLE_PATH`.
 
 ```bash
 # Install the release candidate in the current directory using NPM
@@ -64,8 +70,8 @@ npm install sfdx@latest-rc
 # Target the local sfdx
 export TESTKIT_EXECUTABLE_PATH=./node_modules/.bin/sfdx
 
-# Run NUT test (requires a test-nut script target in the package.json)
-yarn test-nut
+# Run NUT tests (requires a test:nuts script target in the package.json)
+yarn test:nuts
 ```
 
 You will notice that the executable is not configurable in the `execCmd` method directly. If you need to run other commands not located in your plugin, use shelljs directly.
@@ -78,6 +84,22 @@ await exec('sfdx auth:jwt:grant ... --json');
 const result = await execCmd('mycommand --myflag --json');
 ```
 
-## Contributing
+# Environment Variables
 
-TBD
+| Env Var                       | Description                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| TESTKIT_SESSION_DIR           | Overrides the default directory for the test session.                                                           |
+| TESTKIT_HOMEDIR               | Path to a home directory that the tests will use as a stub of os.homedir.                                       |
+| TESTKIT_ORG_USERNAME          | An org username to use for test commands. Tests will use this org rather than creating new orgs.                |
+| TESTKIT_PROJECT_DIR           | A SFDX project to use for testing. The tests will use this project directly rather than creating a new project. |
+| TESTKIT_SAVE_ARTIFACTS        | Prevents a test session from deleting orgs, projects, and test sessions during TestSession.clean().             |
+| TESTKIT_ENABLE_ZIP            | Allows zipping the session dir when this is true and `TestSession.zip()` is called during a test.               |
+| TESTKIT_SETUP_RETRIES         | Number of times to retry the setupCommands after the initial attempt before throwing an error.                  |
+| TESTKIT_SETUP_RETRIES_TIMEOUT | Milliseconds to wait before the next retry of setupCommands. Defaults to 5000.                                  |
+| TESTKIT_HUB_USERNAME          | Username of an existing, authenticated devhub org that TestSession will use to auto-authenticate for tests.     |
+| TESTKIT_JWT_CLIENT_ID         | clientId of the connected app that TestSession will use to auto-authenticate for tests.                         |
+| TESTKIT_JWT_KEY               | JWT key file **contents** that TestSession will use to auto-authenticate for tests.                             |
+| TESTKIT_HUB_INSTANCE          | Instance url for the devhub org. Defaults to https://login.salesforce.com                                       |
+| TESTKIT_AUTH_URL              | Auth url that TestSession will use to auto-authenticate for tests. Uses the `auth:sfdxurl:store` command.       |
+
+# Contributing

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -666,7 +666,7 @@ export TESTKIT_SAVE_ARTIFACTS=true
 
 1. Clean the TestSession in a code block that always runs (e.g., mocha’s after() ) to keep your plugin clean. You can always choose to zip a project or test session after tests run or on each test failure.
 1. Point your CI jobs to different CLI executables using the TESTKIT_EXECUTABLE_PATH env var to ensure your plugin works with the various ways the CLI can be installed. By default it will use your plugin’s `./bin/run` but you can define a local or global npm install path or install from public archives.
-1. Use a naming pattern for test files that use the testkit. These are not unit tests so we like to refer to them as “NUTs” and have a convention of \*.nut.ts so we can run them separately from unit tests.
+1. Use a naming pattern for test files that use the testkit. These are not unit tests so we like to refer to them as “NUTs” and have a convention of `*.nut.ts` so we can run them separately from unit tests.
 1. Use `SFDX_USE_GENERIC_UNIX_KEYCHAIN=true` to prevent authentication keychain issues.
 1. When writing TypeScript NUTs remember to pass the expected type to execCmd so JSON results are typed for you.
 1. Take advantage of TestSession's automatic authentication using the appropriate environment variables.

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "types": "lib/index.d.ts",
   "repository": "https://github.com/salesforcecli/cli-plugins-testkit",
   "scripts": {
-    "build": "sf-build",
+    "build": "sf-build && yarn samples",
     "ci-docs": "yarn sf-ci-docs",
     "clean": "sf-clean",
-    "clean-all": "-clean all",
+    "clean-all": "sf-clean all",
     "compile": "sf-compile",
     "docs": "sf-docs",
     "format": "sf-format",
@@ -20,7 +20,8 @@
     "prepack": "sf-build",
     "pretest": "sf-compile-test",
     "test": "sf-test --require ts-node/register",
-    "codecov": "codecov --disable=gcov"
+    "codecov": "codecov --disable=gcov",
+    "samples": "tsc -p samples && ts-node samples/generateSamplesDoc.ts"
   },
   "keywords": [
     "force",

--- a/samples/.eslintrc.js
+++ b/samples/.eslintrc.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// Generated - Do not modify. Controlled by @salesforce/dev-scripts
+// See more at https://github.com/forcedotcom/sfdx-dev-packages/tree/master/packages/dev-scripts
+
+module.exports = {
+  extends: '../.eslintrc.js',
+  // Allow describe and it
+  env: { mocha: true },
+  rules: {},
+};

--- a/samples/TestSession.sample1.nut.ts
+++ b/samples/TestSession.sample1.nut.ts
@@ -1,0 +1,22 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+      },
+    });
+  });
+
+  it('should run a command from within a generated project', () => {
+    execCmd('force:source:convert', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample10.nut.ts
+++ b/samples/TestSession.sample10.nut.ts
@@ -1,0 +1,25 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import { getString } from '@salesforce/ts-types';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+      },
+      setupCommands: ['sfdx force:org:create edition=Developer'],
+    });
+  });
+
+  it('using testkit to run commands with an org', () => {
+    const username = getString(testSession.setup[0], 'result.username');
+    execCmd(`force:source:deploy -x package.xml -u ${username}`, { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample11.nut.ts
+++ b/samples/TestSession.sample11.nut.ts
@@ -1,0 +1,36 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import { TestProject } from '../src/testProject';
+import { getString } from '@salesforce/ts-types';
+import * as path from 'path';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        sourceDir: path.join(process.cwd(), 'localTestProj'),
+      },
+      setupCommands: ['sfdx force:org:create -f config/project-scratch-def.json'],
+    });
+  });
+
+  it('using testkit to run sync commands', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+
+  it('should create another project and set the cwd stub', () => {
+    // Create another test project and reset the cwd stub
+    const project2 = new TestProject({
+      name: 'project2',
+    });
+    testSession.stubCwd(project2.dir);
+    const username = getString(testSession.setup[0], 'result.username');
+    execCmd(`force:source:pull -u ${username}`);
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample12.nut.ts
+++ b/samples/TestSession.sample12.nut.ts
@@ -1,0 +1,59 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import { getString } from '@salesforce/ts-types';
+import * as shelljs from 'shelljs';
+
+/*
+   NOTE: Scratch orgs can take a while to create so you may want to create them in parallel
+         in a global test fixture and refer to them in your tests.  There are lots of
+         possibilities though and this example shows a few ways how you might create multiple
+         scratch orgs in a test file.
+*/
+
+describe('Sample NUT 1', () => {
+  let testSession: TestSession;
+  const username = 'user@test.org';
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'TestProj1',
+      },
+      setupCommands: [
+        // rely on defaultusername
+        'sfdx force:org:create -f config/project-scratch-def.json -s',
+        // explicitly set a username
+        `sfdx force:org:create -f config/project-scratch-def.json username=${username}`,
+      ],
+    });
+  });
+
+  it('should create a 3rd org and get the username from the json output', () => {
+    const firstOrg = getString(testSession.setup[0], 'result.username');
+    execCmd(`force:source:retrieve -m ApexClass -u ${firstOrg}`, { ensureExitCode: 0 });
+    execCmd(`force:source:retrieve -p force-app -u ${username}`, { ensureExitCode: 0 });
+  });
+
+  it('should create a 3rd org and get the username from the json output', () => {
+    // Note that this org will not be deleted for you by TestSession.
+    const rv = shelljs.exec('sfdx force:org:create -f config/project-scratch-def.json --json');
+    const jsonOutput = JSON.parse(rv.stdout);
+    const thirdOrg = jsonOutput.result.username;
+    execCmd(`force:source:pull -u ${thirdOrg}`);
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});
+
+// Create 2 scratch orgs in parallel.
+describe('Sample NUT 2', () => {
+  before(async () => {
+    // NOTE: this is for demonstration purposes and doesn't work as is
+    //       since shelljs does not return promises, but conveys the point.
+    const org1 = shelljs.exec('sfdx force:org:create edition=Developer', { async: true });
+    const org2 = shelljs.exec('sfdx force:org:create edition=Developer', { async: true });
+    await Promise.all([org1, org2]);
+  });
+});

--- a/samples/TestSession.sample13.nut.ts
+++ b/samples/TestSession.sample13.nut.ts
@@ -1,0 +1,32 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+/*
+   NOTE: you could also change the cwd for one command by overriding in execCmd options.
+*/
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+      },
+    });
+  });
+
+  it('should execute a command from the default cwd', () => {
+    execCmd('config:get defaultusername');
+  });
+
+  it('should execute a command from the new cwd stub', () => {
+    // Change the stubbed process.cwd dir
+    testSession.stubCwd(__dirname);
+    execCmd('config:get defaultusername');
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample2.nut.ts
+++ b/samples/TestSession.sample2.nut.ts
@@ -1,0 +1,23 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import * as path from 'path';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        sourceDir: path.join(process.cwd(), 'localTestProj'),
+      },
+    });
+  });
+
+  it('should run a command from within a locally copied project', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample3.nut.ts
+++ b/samples/TestSession.sample3.nut.ts
@@ -1,0 +1,22 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        gitClone: 'https://github.com/trailheadapps/ebikes-lwc.git',
+      },
+    });
+  });
+
+  it('should run a command from within a cloned github project', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample4.nut.ts
+++ b/samples/TestSession.sample4.nut.ts
@@ -1,0 +1,18 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create();
+  });
+
+  it('should allow access to anything on TestSession without a project', () => {
+    execCmd(`config:set instanceUrl=${testSession.id}`, { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample5.nut.ts
+++ b/samples/TestSession.sample5.nut.ts
@@ -1,0 +1,25 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import { expect } from 'chai';
+import { tmpdir } from 'os';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      // NOTE: you can also override with an env var.
+      //       See section on Testkit env vars.
+      sessionDir: tmpdir(),
+    });
+  });
+
+  it('should use overridden session directory', () => {
+    execCmd(`config:set instanceUrl=${testSession.id}`);
+    expect(testSession.dir).to.equal(tmpdir());
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample6.nut.ts
+++ b/samples/TestSession.sample6.nut.ts
@@ -1,0 +1,18 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create();
+  });
+
+  it('should delete projects, orgs, and the TestSession in after()', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample7.nut.ts
+++ b/samples/TestSession.sample7.nut.ts
@@ -1,0 +1,20 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create();
+  });
+
+  it('should archive the TestSession contents in process.cwd()', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+
+  // NOTE: Must set env var: TESTKIT_ENABLE_ZIP=true
+  after(async () => {
+    await testSession?.zip();
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample8.nut.ts
+++ b/samples/TestSession.sample8.nut.ts
@@ -1,0 +1,24 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create();
+  });
+
+  it('should archive the TestSession contents in process.cwd() when a test fails', () => {
+    execCmd(`config:set instanceUrl=${testSession.id}`, { ensureExitCode: 0 });
+  });
+
+  afterEach(async function () {
+    if (this.currentTest?.state !== 'passed') {
+      await testSession?.zip();
+    }
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/TestSession.sample9.nut.ts
+++ b/samples/TestSession.sample9.nut.ts
@@ -1,0 +1,25 @@
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+import { getString } from '@salesforce/ts-types';
+
+describe('Sample NUT', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+      },
+      setupCommands: ['sfdx force:org:create edition=Developer', 'sfdx force:source:push'],
+    });
+  });
+
+  it('using testkit to run commands with an org', () => {
+    const username = getString(testSession.setup[0], 'result.username');
+    execCmd(`user:create -u ${username}`, { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/execCmd.sample1.nut.ts
+++ b/samples/execCmd.sample1.nut.ts
@@ -1,0 +1,9 @@
+import { execCmd } from '../src/execCmd';
+import { expect } from 'chai';
+
+describe('Sample NUT', () => {
+  it('should run sync commands', () => {
+    const rv = execCmd('config:list');
+    expect(rv.shellOutput).to.contain('successfully did something');
+  });
+});

--- a/samples/execCmd.sample2.nut.ts
+++ b/samples/execCmd.sample2.nut.ts
@@ -1,0 +1,9 @@
+import { execCmd } from '../src/execCmd';
+import { expect } from 'chai';
+
+describe('Sample NUT', () => {
+  it('should run async commands', async () => {
+    const rv = await execCmd('config:list', { async: true });
+    expect(rv.shellOutput).to.contain('successfully did something');
+  });
+});

--- a/samples/execCmd.sample3.nut.ts
+++ b/samples/execCmd.sample3.nut.ts
@@ -1,0 +1,7 @@
+import { execCmd } from '../src/execCmd';
+
+describe('Sample NUT', () => {
+  it('should ensure a specific exit code', () => {
+    execCmd('config:list', { ensureExitCode: 0 });
+  });
+});

--- a/samples/execCmd.sample4.nut.ts
+++ b/samples/execCmd.sample4.nut.ts
@@ -1,0 +1,10 @@
+import { execCmd } from '../src/execCmd';
+
+describe('Sample NUT', () => {
+  // This would actually be set in the shell or CI environment.
+  process.env.TESTKIT_EXECUTABLE_PATH = 'sfdx';
+
+  it('should use the specified Salesforce CLI executable', () => {
+    execCmd('config:list');
+  });
+});

--- a/samples/execCmd.sample5.nut.ts
+++ b/samples/execCmd.sample5.nut.ts
@@ -1,0 +1,17 @@
+import { execCmd } from '../src/execCmd';
+import { expect } from 'chai';
+
+// This would typically be imported from your command.
+type ConfigResult = {
+  key: string;
+  location: string;
+  value: string;
+};
+
+describe('Sample NUT', () => {
+  it('should provide typed and parsed JSON output', () => {
+    // Simply have your command use the --json flag and provide a type.
+    const rv = execCmd<ConfigResult[]>('config:list --json').jsonOutput;
+    expect(rv.result[0].key).equals('defaultdevhubusername');
+  });
+});

--- a/samples/execCmd.sample6.nut.ts
+++ b/samples/execCmd.sample6.nut.ts
@@ -1,0 +1,12 @@
+import { execCmd } from '../src/execCmd';
+import { expect } from 'chai';
+
+describe('Sample NUT', () => {
+  it('config:list should execute in less than 5 seconds', () => {
+    const t1 = execCmd(`config:list`).execCmdDuration.milliseconds;
+    const t2 = execCmd(`config:list`).execCmdDuration.milliseconds;
+    const t3 = execCmd(`config:list`).execCmdDuration.milliseconds;
+    const aveExecTime = (t1 + t2 + t3) / 3;
+    expect(aveExecTime).to.be.lessThan(5000);
+  });
+});

--- a/samples/generateSamplesDoc.ts
+++ b/samples/generateSamplesDoc.ts
@@ -61,10 +61,10 @@ function replaceImports(nut: string): string {
         const samplesContent = content as SamplesContent;
         const header = samplesContent.header;
         const headerLink = header.replace(/\s+/g, '-').toLowerCase();
-        tableOfContents.push(`* [${header}](#${headerLink})${os.EOL}`);
+        tableOfContents.push(`- [${header}](#${headerLink})${os.EOL}`);
 
         sampleContents.push(`## ${header}${os.EOL}${os.EOL}`);
-        sampleContents.push(`***Usecase: ${samplesContent.usecase}***${os.EOL}${os.EOL}`);
+        sampleContents.push(`**_Usecase: ${samplesContent.usecase}_**${os.EOL}${os.EOL}`);
 
         if (samplesContent.file) {
           sampleContents.push(`\`\`\`${topic.type}${os.EOL}`);

--- a/samples/generateSamplesDoc.ts
+++ b/samples/generateSamplesDoc.ts
@@ -41,7 +41,6 @@ function replaceImports(nut: string): string {
   }
   // Replace the last blank line if it exists to satisfy the .md linter
   if (replacedNut.endsWith(os.EOL)) {
-    console.log('Replacing line ending');
     replacedNut = replacedNut.replace(/[\n]$/g, '');
   }
   return replacedNut;

--- a/samples/generateSamplesDoc.ts
+++ b/samples/generateSamplesDoc.ts
@@ -39,6 +39,11 @@ function replaceImports(nut: string): string {
     const libImport = `import { ${imports.join(', ')} } from '@salesforce/cli-plugins-testkit';${os.EOL}`;
     replacedNut = `${libImport}${replacedNut}`;
   }
+  // Replace the last blank line if it exists to satisfy the .md linter
+  if (replacedNut.endsWith(os.EOL)) {
+    console.log('Replacing line ending');
+    replacedNut = replacedNut.replace(/[\n]$/g, '');
+  }
   return replacedNut;
 }
 
@@ -52,8 +57,8 @@ function replaceImports(nut: string): string {
   let sampleContents: string[] = [];
 
   for (let topic of topics) {
-    tableOfContents.push(`### ${topic.name} ###${os.EOL}`);
-    sampleContents.push(`${os.EOL}---${os.EOL}# ${topic.title}${os.EOL}${os.EOL}`);
+    tableOfContents.push(`${os.EOL}### ${topic.name}${os.EOL}${os.EOL}`);
+    sampleContents.push(`---${os.EOL}${os.EOL}# ${topic.title}${os.EOL}${os.EOL}`);
     topic.description && sampleContents.push(`${topic.description}${os.EOL}${os.EOL}`);
 
     if (['typescript', 'bash'].includes(topic.type)) {
@@ -86,7 +91,7 @@ function replaceImports(nut: string): string {
       // Assume inline if not bash or typescript topic type.
       const title = topic.title;
       const titleLink = title.replace(/\s+/g, '-').toLowerCase();
-      tableOfContents.push(`* [${title}](#${titleLink})${os.EOL}`);
+      tableOfContents.push(`- [${title}](#${titleLink})${os.EOL}${os.EOL}`);
       const inlineContent = topic.content as string[];
       for (let line of inlineContent) {
         sampleContents.push(`${line}${os.EOL}`);

--- a/samples/generateSamplesDoc.ts
+++ b/samples/generateSamplesDoc.ts
@@ -1,0 +1,100 @@
+import * as path from 'path';
+import * as os from 'os';
+import { fs as fsCore } from '@salesforce/core';
+
+// The structure of topic content in topics.json.
+type SamplesContent = {
+  header: string;
+  usecase: string;
+  file?: string;
+  script?: string;
+};
+
+// Top level type in topics.json.  Represents a section within the doc.
+type SamplesTopic = {
+  name: string;
+  title: string;
+  type: 'typescript' | 'bash' | 'inline';
+  description?: string;
+  content: SamplesContent[] | string[];
+};
+
+const importsToReplace = new Map<string, string>();
+importsToReplace.set('execCmd', `import { execCmd } from '../src/execCmd';${os.EOL}`);
+importsToReplace.set('TestSession', `import { TestSession } from '../src/testSession';${os.EOL}`);
+importsToReplace.set('TestProject', `import { TestProject } from '../src/testProject';${os.EOL}`);
+
+// Replaces local imports for nut samples compilation with equivalent library import.
+function replaceImports(nut: string): string {
+  let imports: string[] = [];
+  let replacedNut = nut;
+
+  importsToReplace.forEach((val, key) => {
+    if (nut.includes(key)) {
+      replacedNut = replacedNut.replace(val, '');
+      imports.push(key);
+    }
+  });
+  if (imports.length) {
+    const libImport = `import { ${imports.join(', ')} } from '@salesforce/cli-plugins-testkit';${os.EOL}`;
+    replacedNut = `${libImport}${replacedNut}`;
+  }
+  return replacedNut;
+}
+
+// Reads topics.json for configuration and doc structure. Writes SAMPLES.md.
+(function generateSamples() {
+  const topics = fsCore.readJsonSync(path.join(__dirname, 'topics.json')) as SamplesTopic[];
+
+  const fileModificationWarning = `<!--${os.EOL}WARNING: THIS IS A GENERATED FILE. DO NOT MODIFY DIRECTLY.  USE topics.json${os.EOL}-->${os.EOL}`;
+
+  let tableOfContents: string[] = [fileModificationWarning];
+  let sampleContents: string[] = [];
+
+  for (let topic of topics) {
+    tableOfContents.push(`### ${topic.name} ###${os.EOL}`);
+    sampleContents.push(`${os.EOL}---${os.EOL}# ${topic.title}${os.EOL}${os.EOL}`);
+    topic.description && sampleContents.push(`${topic.description}${os.EOL}${os.EOL}`);
+
+    if (['typescript', 'bash'].includes(topic.type)) {
+      for (let content of topic.content) {
+        const samplesContent = content as SamplesContent;
+        const header = samplesContent.header;
+        const headerLink = header.replace(/\s+/g, '-').toLowerCase();
+        tableOfContents.push(`* [${header}](#${headerLink})${os.EOL}`);
+
+        sampleContents.push(`## ${header}${os.EOL}${os.EOL}`);
+        sampleContents.push(`***Usecase: ${samplesContent.usecase}***${os.EOL}${os.EOL}`);
+
+        if (samplesContent.file) {
+          sampleContents.push(`\`\`\`${topic.type}${os.EOL}`);
+          const nut = fsCore.readFileSync(path.join(__dirname, samplesContent.file)).toString();
+          const replacedNut = replaceImports(nut);
+          sampleContents.push(`${replacedNut}${os.EOL}`);
+          sampleContents.push(`\`\`\`${os.EOL}${os.EOL}`);
+        }
+
+        if (samplesContent.script) {
+          sampleContents.push(`\`\`\`${topic.type}${os.EOL}`);
+          for (let line of samplesContent.script) {
+            sampleContents.push(`${line}${os.EOL}`);
+          }
+          sampleContents.push(`\`\`\`${os.EOL}${os.EOL}`);
+        }
+      }
+    } else {
+      // Assume inline if not bash or typescript topic type.
+      const title = topic.title;
+      const titleLink = title.replace(/\s+/g, '-').toLowerCase();
+      tableOfContents.push(`* [${title}](#${titleLink})${os.EOL}`);
+      const inlineContent = topic.content as string[];
+      for (let line of inlineContent) {
+        sampleContents.push(`${line}${os.EOL}`);
+      }
+    }
+  }
+
+  const samplesFileContent = [...tableOfContents, ...sampleContents];
+  const samplesFilePath = path.join(process.cwd(), 'SAMPLES.md');
+  fsCore.writeFileSync(samplesFilePath, samplesFileContent.join(''));
+})();

--- a/samples/topics.json
+++ b/samples/topics.json
@@ -1,0 +1,183 @@
+[
+  {
+    "name": "execCmd Function",
+    "title": "Using Testkit’s execCmd function",
+    "type": "typescript",
+    "description": "The execCmd function allows plugin commands to execute with a specific CLI executable, defaulting to the plugin’s `./bin/run`.  It can automatically ensure a specific exit code and throw an error when that exit code is not returned.  Commands can be executed synchronously or asynchronously.  All command results exitCode, stdout, and stderr are returned.  If the --json flag was provided the results will have the parsed JSON output.  Command execution time is provided as a Duration object for easy manipulation.",
+    "content": [
+      {
+        "header": "Testing plugin commands synchronously",
+        "usecase": "I have a plugin with commands that I want to run within tests synchronously using my plugin’s `./bin/run`.",
+        "file": "execCmd.sample1.nut.ts"
+      },
+      {
+        "header": "Testing plugin commands asynchronously",
+        "usecase": "I have a plugin with commands that I want to run within tests asynchronously.",
+        "file": "execCmd.sample2.nut.ts"
+      },
+      {
+        "header": "Testing plugin commands exit code",
+        "usecase": "I have a plugin with commands that I want to run and throw an error if a certain exit code is not returned automatically.",
+        "file": "execCmd.sample3.nut.ts"
+      },
+      {
+        "header": "Testing plugin commands with a specific Salesforce CLI executable",
+        "usecase": "I have a plugin with commands that I want to run with a specific Salesforce CLI executable rather than my plugin’s `./bin/run`.",
+        "file": "execCmd.sample4.nut.ts"
+      },
+      {
+        "header": "Testing plugin commands JSON output",
+        "usecase": "I have a plugin with commands that I want to run and have parsed JSON output returned for easy verification.",
+        "file": "execCmd.sample5.nut.ts"
+      },
+      {
+        "header": "Getting command execution times",
+        "usecase": "I want to ensure my plugin commands execute within an acceptable duration range.",
+        "file": "execCmd.sample6.nut.ts"
+      }
+    ]
+  },
+  {
+    "name": "TestSession Class",
+    "title": "Using Testkit’s TestSession class",
+    "type": "typescript",
+    "description": "A TestSession provides conveniences to testing plugin commands with options to authenticate to a devhub, create scratch orgs, define SFDX test projects, stub the current working directory of a process, run a list of setup commands, archive the contents of a test session, and use a unique identifier.",
+    "content": [
+      {
+        "header": "Testing with generated sfdx project",
+        "usecase": "I have a plugin with commands that require a SFDX project but the tests don’t care about the contents of the project.",
+        "file": "TestSession.sample1.nut.ts"
+      },
+      {
+        "header": "Testing with local sfdx project",
+        "usecase": "I have a plugin with commands that require a SFDX project and the test project I want to use is in a local directory within my plugin repo.",
+        "file": "TestSession.sample2.nut.ts"
+      },
+      {
+        "header": "Testing with git cloned sfdx project",
+        "usecase": "I have a plugin with commands that require a SFDX project and the test project I want to use is in a git repo.",
+        "file": "TestSession.sample3.nut.ts"
+      },
+      {
+        "header": "Testing with no sfdx project",
+        "usecase": "I have a plugin with commands that do not require a SFDX project but I want other things from a TestSession such as easy authentication to a devhub, setup commands, homedir stub, etc.",
+        "file": "TestSession.sample4.nut.ts"
+      },
+      {
+        "header": "Override the location of a TestSession",
+        "usecase": "I want my tests to control the location of the TestSession.",
+        "file": "TestSession.sample5.nut.ts"
+      },
+      {
+        "header": "Cleaning TestSessions",
+        "usecase": "I want to use TestSessions but clean everything when the tests are done running, including projects, scratch orgs, and the TestSession directory.",
+        "file": "TestSession.sample6.nut.ts"
+      },
+      {
+        "header": "Archiving TestSessions",
+        "usecase": "I want to use TestSessions but zip the test session directory when the tests are done running.",
+        "file": "TestSession.sample7.nut.ts"
+      },
+      {
+        "header": "Archiving TestSessions on test failure",
+        "usecase": "I want to use TestSessions but zip the test session directory when the tests fail.",
+        "file": "TestSession.sample8.nut.ts"
+      },
+      {
+        "header": "Testing with setup commands",
+        "usecase": "I have a plugin with commands and tests require other commands to run for setup, and I want to reference the command results of the setup commands.",
+        "file": "TestSession.sample9.nut.ts"
+      },
+      {
+        "header": "Testing with scratch orgs",
+        "usecase": "I have a plugin with commands that require an org.",
+        "file": "TestSession.sample10.nut.ts"
+      },
+      {
+        "header": "Testing with multiple test projects",
+        "usecase": "Some of my plugin command tests require multiple SFDX test projects.",
+        "file": "TestSession.sample11.nut.ts"
+      },
+      {
+        "header": "Testing with multiple scratch orgs",
+        "usecase": "Some of my plugin command tests require multiple scratch orgs.",
+        "file": "TestSession.sample12.nut.ts"
+      },
+      {
+        "header": "Changing the process.cwd stub",
+        "usecase": "The TestSession stubs process.cwd() to my SFDX project for me, but I want to change it during testing.",
+        "file": "TestSession.sample13.nut.ts"
+      }
+    ]
+  },
+  {
+    "name": "Environment Variables",
+    "title": "Configuring Testkit with Environment Variables",
+    "type": "bash",
+    "content": [
+      {
+        "header": "Testkit Debug output",
+        "usecase": "I want to see all the stuff that the testkit is doing, either because I’m curious or need to troubleshoot.",
+        "script": [
+          "# To see all testkit debug output, in your shell",
+          "export DEBUG=testkit:*",
+          "# To see specific debug output (e.g., project setup), in your shell",
+          "export DEBUG=testkit:project"
+        ]
+      },
+      {
+        "header": "Testing with existing devhub authentication",
+        "usecase": "I have a plugin with commands that require devhub authentication before running, and I want to use my current devhub auth config.",
+        "script": ["export TESTKIT_HUB_USERNAME=test1@scratch.org"]
+      },
+      {
+        "header": "Testing with SFDX Auth URL",
+        "usecase": "I have a plugin with commands that require devhub authentication before running, and I want to use a SFDX auth URL.",
+        "script": ["export TESTKIT_AUTH_URL=test1@scratch.org"]
+      },
+      {
+        "header": "Testing with JWT devhub authentication",
+        "usecase": "I have a plugin with commands that require devhub authentication before running, and I want to use a JWT devhub auth config.",
+        "script": [
+          "# Ensure caution with the JWT key file contents! E.g., Set within protected Circle CI env vars.",
+          "export TESTKIT_HUB_USERNAME=test1@scratch.org",
+          "export TESTKIT_JWT_CLIENT_ID=<clientID>",
+          "export TESTKIT_JWT_KEY=<contents of the jwt key file>"
+        ]
+      },
+      {
+        "header": "Reusing orgs during test runs",
+        "usecase": "I want the tests to use a specific scratch org or reuse one from a previous test run. Tests should not create scratch orgs.",
+        "script": ["export TESTKIT_ORG_USERNAME=test1@scratch.org"]
+      },
+      {
+        "header": "Reusing projects during test runs",
+        "usecase": "I want the tests to use a specific SFDX project directory and not copy one into a TestSession dir.  Or I kept the test artifacts from a previous run and want to reuse them.",
+        "script": ["export TESTKIT_PROJECT_DIR=/Users/me/projects/MyTestProject"]
+      },
+      {
+        "header": "Using my actual homedir during test runs",
+        "usecase": "I want to have the tests use my actual home directory, not a temporary stubbed home dir.",
+        "script": ["export TESTKIT_HOMEDIR=/Users/me"]
+      },
+      {
+        "header": "Saving test artifacts after test runs",
+        "usecase": "I want to keep the test project, scratch org, and test session dir after the tests are done running to troubleshoot.",
+        "script": ["export TESTKIT_SAVE_ARTIFACTS=true"]
+      }
+    ]
+  },
+  {
+    "name": "Best Practices",
+    "title": "Testkit Best Practices",
+    "type": "inline",
+    "content": [
+      "1. Clean the TestSession in a code block that always runs (e.g., mocha’s after() ) to keep your plugin clean.  You can always choose to zip a project or test session after tests run or on each test failure.",
+      "1. Point your CI jobs to different CLI executables using the TESTKIT_EXECUTABLE_PATH env var to ensure your plugin works with the various ways the CLI can be installed.  By default it will use your plugin’s `./bin/run` but you can define a local or global npm install path or install from public archives.",
+      "1. Use a naming pattern for test files that use the testkit.  These are not unit tests so we like to refer to them as “NUTs” and have a convention of *.nut.ts so we can run them separately from unit tests.",
+      "1. Use `SFDX_USE_GENERIC_UNIX_KEYCHAIN=true` to prevent authentication keychain issues.",
+      "1. When writing TypeScript NUTs remember to pass the expected type to execCmd so JSON results are typed for you.",
+      "1. Take advantage of TestSession's automatic authentication using the appropriate environment variables."
+    ]
+  }
+]

--- a/samples/topics.json
+++ b/samples/topics.json
@@ -3,7 +3,7 @@
     "name": "execCmd Function",
     "title": "Using Testkit’s execCmd function",
     "type": "typescript",
-    "description": "The execCmd function allows plugin commands to execute with a specific CLI executable, defaulting to the plugin’s `./bin/run`.  It can automatically ensure a specific exit code and throw an error when that exit code is not returned.  Commands can be executed synchronously or asynchronously.  All command results exitCode, stdout, and stderr are returned.  If the --json flag was provided the results will have the parsed JSON output.  Command execution time is provided as a Duration object for easy manipulation.",
+    "description": "The execCmd function allows plugin commands to execute with a specific CLI executable, defaulting to the plugin’s `./bin/run`. It can automatically ensure a specific exit code and throw an error when that exit code is not returned. Commands can be executed synchronously or asynchronously. All command results exitCode, stdout, and stderr are returned. If the --json flag was provided the results will have the parsed JSON output. Command execution time is provided as a Duration object for easy manipulation.",
     "content": [
       {
         "header": "Testing plugin commands synchronously",
@@ -152,7 +152,7 @@
       },
       {
         "header": "Reusing projects during test runs",
-        "usecase": "I want the tests to use a specific SFDX project directory and not copy one into a TestSession dir.  Or I kept the test artifacts from a previous run and want to reuse them.",
+        "usecase": "I want the tests to use a specific SFDX project directory and not copy one into a TestSession dir. Or I kept the test artifacts from a previous run and want to reuse them.",
         "script": ["export TESTKIT_PROJECT_DIR=/Users/me/projects/MyTestProject"]
       },
       {
@@ -172,9 +172,9 @@
     "title": "Testkit Best Practices",
     "type": "inline",
     "content": [
-      "1. Clean the TestSession in a code block that always runs (e.g., mocha’s after() ) to keep your plugin clean.  You can always choose to zip a project or test session after tests run or on each test failure.",
-      "1. Point your CI jobs to different CLI executables using the TESTKIT_EXECUTABLE_PATH env var to ensure your plugin works with the various ways the CLI can be installed.  By default it will use your plugin’s `./bin/run` but you can define a local or global npm install path or install from public archives.",
-      "1. Use a naming pattern for test files that use the testkit.  These are not unit tests so we like to refer to them as “NUTs” and have a convention of *.nut.ts so we can run them separately from unit tests.",
+      "1. Clean the TestSession in a code block that always runs (e.g., mocha’s after() ) to keep your plugin clean. You can always choose to zip a project or test session after tests run or on each test failure.",
+      "1. Point your CI jobs to different CLI executables using the TESTKIT_EXECUTABLE_PATH env var to ensure your plugin works with the various ways the CLI can be installed. By default it will use your plugin’s `./bin/run` but you can define a local or global npm install path or install from public archives.",
+      "1. Use a naming pattern for test files that use the testkit. These are not unit tests so we like to refer to them as “NUTs” and have a convention of `*.nut.ts` so we can run them separately from unit tests.",
       "1. Use `SFDX_USE_GENERIC_UNIX_KEYCHAIN=true` to prevent authentication keychain issues.",
       "1. When writing TypeScript NUTs remember to pass the expected type to execCmd so JSON results are typed for you.",
       "1. Take advantage of TestSession's automatic authentication using the appropriate environment variables."

--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../node_modules/@salesforce/dev-config/tsconfig",
+  "include": ["*.nut.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Generates a SAMPLES.md doc that is built from compiled sample source and a configuration file called topics.json.
Also updates the README.md doc a bit.

To compile the sample source and generate the samples doc run `yarn samples`.  This script is also hooked into `yarn build` so the samples doc is generated during a build.