### PR TITLE
feat: add the ability to override the default shell used by shelljs.exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Using a different file extension will help separate your unit tests from your NU
 # Example NUTs
 
 Here are some public github repos for plugins that use this library for NUTs:
+
 - [@salesforce/plugin-alias](https://github.com/salesforcecli/plugin-alias/blob/main/test/commands/alias/set.nut.ts)
 - [@salesforce/plugin-auth](https://github.com/salesforcecli/plugin-auth/blob/main/test/commands/auth/list.nut.ts)
 - [@salesforce/plugin-config](https://github.com/salesforcecli/plugin-config/blob/main/test/commands/config/list.nut.ts)
@@ -96,6 +97,7 @@ const result = await execCmd('mycommand --myflag --json');
 | TESTKIT_ENABLE_ZIP            | Allows zipping the session dir when this is true and `TestSession.zip()` is called during a test.               |
 | TESTKIT_SETUP_RETRIES         | Number of times to retry the setupCommands after the initial attempt before throwing an error.                  |
 | TESTKIT_SETUP_RETRIES_TIMEOUT | Milliseconds to wait before the next retry of setupCommands. Defaults to 5000.                                  |
+| TESTKIT_EXEC_SHELL            | The shell to use for all testkit shell executions rather than the shelljs default.                              |
 | TESTKIT_HUB_USERNAME          | Username of an existing, authenticated devhub org that TestSession will use to auto-authenticate for tests.     |
 | TESTKIT_JWT_CLIENT_ID         | clientId of the connected app that TestSession will use to auto-authenticate for tests.                         |
 | TESTKIT_JWT_KEY               | JWT key file **contents** that TestSession will use to auto-authenticate for tests.                             |

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -37,6 +37,7 @@ WARNING: THIS IS A GENERATED FILE. DO NOT MODIFY DIRECTLY.  USE topics.json
 - [Reusing projects during test runs](#reusing-projects-during-test-runs)
 - [Using my actual homedir during test runs](#using-my-actual-homedir-during-test-runs)
 - [Saving test artifacts after test runs](#saving-test-artifacts-after-test-runs)
+- [Overriding the default shell](#overriding-the-default-shell)
 
 ### Best Practices
 
@@ -658,6 +659,14 @@ export TESTKIT_HOMEDIR=/Users/me
 
 ```bash
 export TESTKIT_SAVE_ARTIFACTS=true
+```
+
+## Overriding the default shell
+
+**_Usecase: I want the testkit to use a different shell rather than the default shelljs shell._**
+
+```bash
+export TESTKIT_EXEC_SHELL=powershell.exe
 ```
 
 ---

--- a/samples/topics.json
+++ b/samples/topics.json
@@ -164,6 +164,11 @@
         "header": "Saving test artifacts after test runs",
         "usecase": "I want to keep the test project, scratch org, and test session dir after the tests are done running to troubleshoot.",
         "script": ["export TESTKIT_SAVE_ARTIFACTS=true"]
+      },
+      {
+        "header": "Overriding the default shell",
+        "usecase": "I want the testkit to use a different shell rather than the default shelljs shell.",
+        "script": ["export TESTKIT_EXEC_SHELL=powershell.exe"]
       }
     ]
   },

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -53,12 +53,16 @@ export interface ExecCmdResult<T = AnyJson> {
 }
 
 const buildCmdOptions = (options?: ExecCmdOptions): ExecCmdOptions => {
-  const defaults = {
+  const defaults: shelljs.ExecOptions = {
     env: Object.assign({}, process.env),
     cwd: process.cwd(),
     timeout: 300000, // 5 minutes
     silent: true,
   };
+  const shellOverride = env.getString('TESTKIT_EXEC_SHELL');
+  if (shellOverride) {
+    defaults.shell = shellOverride;
+  }
   return { ...defaults, ...options };
 };
 

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -131,6 +131,20 @@ describe('execCmd (sync)', () => {
     expect(result.jsonError?.name).to.equal('JsonParseError');
     expect(result.jsonError?.message).to.equal(`Parse error in file unknown on line 1${EOL}try JSON parsing this`);
   });
+
+  it('should override shell default', () => {
+    const shellOverride = 'powershell.exe';
+    stubMethod(sandbox, env, 'getString')
+      .withArgs('TESTKIT_EXECUTABLE_PATH')
+      .returns(null)
+      .withArgs('TESTKIT_EXEC_SHELL')
+      .returns(shellOverride);
+    sandbox.stub(fs, 'fileExistsSync').returns(true);
+    const shellString = new ShellString(JSON.stringify(output));
+    const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
+    execCmd(cmd);
+    expect(execStub.args[0][1]).to.have.property('shell', shellOverride);
+  });
 });
 
 describe('execCmd (async)', () => {
@@ -234,5 +248,19 @@ describe('execCmd (async)', () => {
     expect(result.jsonError).to.be.an('Error');
     expect(result.jsonError?.name).to.equal('JsonParseError');
     expect(result.jsonError?.message).to.equal(`Parse error in file unknown on line 1${EOL}try JSON parsing this`);
+  });
+
+  it('should override shell default', async () => {
+    const shellOverride = 'powershell.exe';
+    stubMethod(sandbox, env, 'getString')
+      .withArgs('TESTKIT_EXECUTABLE_PATH')
+      .returns(null)
+      .withArgs('TESTKIT_EXEC_SHELL')
+      .returns(shellOverride);
+    sandbox.stub(fs, 'fileExistsSync').returns(true);
+    const shellString = new ShellString(JSON.stringify(output));
+    const execStub = stubMethod(sandbox, shelljs, 'exec').yields(0, shellString, '');
+    await execCmd(cmd, { async: true });
+    expect(execStub.args[0][1]).to.have.property('shell', shellOverride);
   });
 });

--- a/test/unit/testProject.test.ts
+++ b/test/unit/testProject.test.ts
@@ -12,6 +12,7 @@ import * as sinon from 'sinon';
 import * as shelljs from 'shelljs';
 import { ShellString } from 'shelljs';
 import { stubMethod } from '@salesforce/ts-sinon';
+import { env } from '@salesforce/kit';
 import { fs as fsCore } from '@salesforce/core';
 import { TestProject } from '../../lib/testProject';
 
@@ -93,6 +94,8 @@ describe('TestProject', () => {
 
   it('should generate from a name', () => {
     stubMethod(sandbox, shelljs, 'which').returns(true);
+    const shellOverride = 'powershell.exe';
+    stubMethod(sandbox, env, 'getString').returns(shellOverride);
     const shellString = new ShellString('');
     shellString.code = 0;
     const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
@@ -102,6 +105,7 @@ describe('TestProject', () => {
     expect(testProject.dir).to.equal(pathJoin(destinationDir, name));
     const execArg1 = `sfdx force:project:create -n ${name} -d ${destinationDir}`;
     expect(execStub.firstCall.args[0]).to.equal(execArg1);
+    expect(execStub.firstCall.args[1]).to.have.property('shell', shellOverride);
   });
 
   it('should generate by default', () => {

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -149,6 +149,13 @@ describe('TestSession', () => {
 
     it('should create a session with setup commands', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
+      const homedir = path.join('some', 'other', 'home');
+      const shellOverride = 'powershell.exe';
+      stubMethod(sandbox, env, 'getString')
+        .withArgs('TESTKIT_EXEC_SHELL')
+        .returns(shellOverride)
+        .withArgs('TESTKIT_HOMEDIR')
+        .returns(homedir);
       const setupCommands = ['sfdx foo:bar -r testing'];
       const execRv = { result: { donuts: 'yum' } };
       const shellString = new ShellString(JSON.stringify(execRv));
@@ -162,10 +169,11 @@ describe('TestSession', () => {
       expect(session.id).to.be.a('string');
       expect(session.createdDate).to.be.a('Date');
       expect(session.dir).to.equal(path.join(cwd, `test_session_${session.id}`));
-      expect(session.homeDir).to.equal(session.dir);
+      expect(session.homeDir).to.equal(homedir);
       expect(session.project).to.equal(undefined);
       expect(session.setup).to.deep.equal([execRv]);
       expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
+      expect(execStub.firstCall.args[1]).to.have.property('shell', shellOverride);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });


### PR DESCRIPTION
This adds the TESTKIT_EXEC_SHELL env var which allows tests to specify a shell other than the default used by shelljs, which is the same default as child_process.  This shell will be used everywhere shelljs.exec() is called.  It will still be possible to use the env var to override the shell but use a specific one when calling `execCmd()`.

This affect:
execCmd()
TestSession setupCommands
TestProject creation with git clone or project:create

@W-8996057@