### PR TITLE
fix: revert access token support

### DIFF
--- a/src/hubAuth.ts
+++ b/src/hubAuth.ts
@@ -17,7 +17,6 @@ import { env } from '@salesforce/kit';
 export enum AuthStrategy {
   JWT = 'JWT',
   AUTH_URL = 'AUTH_URL',
-  ACCESS_TOKEN = 'ACCESS_TOKEN',
   REUSE = 'REUSE',
   NONE = 'NONE',
 }
@@ -58,12 +57,6 @@ export const prepareForJwt = (homeDir: string): string => {
   return jwtKey;
 };
 
-export const prepareForAccessToken = (homeDir: string): string => {
-  const accessTokenFile = path.join(homeDir, 'accessTokenFile');
-  fs.writeFileSync(accessTokenFile, env.getString('TESTKIT_AUTH_ACCESS_TOKEN', ''));
-  return accessTokenFile;
-};
-
 export const prepareForAuthUrl = (homeDir: string): string => {
   const tmpUrl = path.join(homeDir, 'tmpUrl');
   fs.writeFileSync(tmpUrl, env.getString('TESTKIT_AUTH_URL', ''));
@@ -71,7 +64,7 @@ export const prepareForAuthUrl = (homeDir: string): string => {
 };
 
 /**
- * Inspects the environment (via AuthStrategy) and authenticates to a devhub via JWT, AuthUrl or AccessToken
+ * Inspects the environment (via AuthStrategy) and authenticates to a devhub via JWT or AuthUrl
  * Sets the hub as default for use in tests
  *
  * @param homeDir the testSession directory where credential files will be written
@@ -81,7 +74,6 @@ export const prepareForAuthUrl = (homeDir: string): string => {
  *   for jwt: TESTKIT_HUB_USERNAME, TESTKIT_JWT_CLIENT_ID, TESTKIT_JWT_KEY
  *     optional but recommended: TESTKIT_HUB_INSTANCE
  *   required for AuthUrl: TESTKIT_AUTH_URL
- *   required for AccessToken: TESTKIT_AUTH_ACCESS_TOKEN, TESTKIT_HUB_INSTANCE
  */
 export const testkitHubAuth = (homeDir: string, authStrategy: AuthStrategy = getAuthStrategy()): void => {
   const logger = debug('testkit:authFromStubbedHome');
@@ -112,7 +104,6 @@ export const testkitHubAuth = (homeDir: string, authStrategy: AuthStrategy = get
     }
     return;
   }
-
   if (authStrategy === AuthStrategy.AUTH_URL) {
     logger('trying to authenticate with AuthUrl');
 
@@ -130,29 +121,6 @@ export const testkitHubAuth = (homeDir: string, authStrategy: AuthStrategy = get
 
     return;
   }
-
-  if (authStrategy === AuthStrategy.ACCESS_TOKEN) {
-    logger('trying to authenticate with Access Token');
-
-    const accessTokenFile = prepareForAccessToken(homeDir);
-
-    const shellOutput = shell.exec(
-      `sfdx auth:accesstoken:store --noprompt -d -f ${accessTokenFile} -r ${env.getString(
-        'TESTKIT_HUB_INSTANCE',
-        DEFAULT_INSTANCE_URL
-      )}`,
-      execOpts
-    ) as shell.ShellString;
-    logger(shellOutput);
-    if (shellOutput.code !== 0) {
-      throw new Error(
-        `auth:sfdxurl for url ${accessTokenFile} failed with exit code: ${shellOutput.code}\n ${
-          shellOutput.stdout + shellOutput.stderr
-        }`
-      );
-    }
-    return;
-  }
   logger('no hub configured');
 };
 
@@ -166,9 +134,6 @@ const getAuthStrategy = (): AuthStrategy => {
   }
   if (env.getString('TESTKIT_AUTH_URL')) {
     return AuthStrategy.AUTH_URL;
-  }
-  if (env.getString('TESTKIT_AUTH_ACCESS_TOKEN') && env.getString('TESTKIT_HUB_INSTANCE')) {
-    return AuthStrategy.ACCESS_TOKEN;
   }
   // none of the above are included, so we want to reuse an already authenticated hub
   if (env.getString('TESTKIT_HUB_USERNAME')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 
 export * from './genUniqueString';
 export * from './execCmd';
-export { prepareForAuthUrl, prepareForJwt, prepareForAccessToken } from './hubAuth';
+export { prepareForAuthUrl, prepareForJwt } from './hubAuth';
 export * from './testProject';
 export * from './testSession';
 export { Duration } from '@salesforce/kit';

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -72,7 +72,6 @@ export interface TestSessionOptions {
  *   TESTKIT_JWT_KEY = JWT key (not a filepath, the actual contents of the key)
  *   TESTKIT_HUB_INSTANCE = instance url for the hub.  Defaults to https://login.salesforce.com
  *   TESTKIT_AUTH_URL = auth url to be used with auth:sfdxurl:store
- *   TESTKIT_AUTH_ACCESS_TOKEN = access token to be used with auth:accesstoken:store
  */
 export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
   public id: string;

--- a/test/unit/hubAuth.test.ts
+++ b/test/unit/hubAuth.test.ts
@@ -9,8 +9,6 @@ describe('hubAuth', () => {
   it('works with existing defaultdevhub if provided');
   it('auths from authurl in env');
   it('auths from authurl and sets as default');
-  it('auths from access token and sets as default');
-  it('auths from access token');
   it('auths from jwt in env');
   it('auths from jwt with custom hubAlias');
 });


### PR DESCRIPTION
Really does not make sense to support access token auth for testkit, nuts, etc.