### PR TITLE
chore: change circle config test-package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,24 +10,23 @@ workflows:
             branches:
               ignore: main
       - release-management/test-package:
-          name: node-latest
-          node_version: latest
-          upload-coverage: true
-      - release-management/test-package:
-          node_version: '14'
-          name: node-14
-      - release-management/test-package:
-          node_version: '12'
-          name: node-12
-      - release-management/test-package:
-          node_version: '10'
-          name: node-10
+          matrix:
+            parameters:
+              os:
+                - linux
+                - windows
+              node_version:
+                - latest
+                - lts
+                - maintenance
+            exclude:
+              - os: windows
+                node_version: lts
+              - os: windows
+                node_version: maintenance
       - release-management/release-package:
           requires:
-            - node-latest
-            - node-14
-            - node-12
-            - node-10
+            - release-management/test-package
           filters:
             branches:
               only: main

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { EOL } from 'os';
 import { join } from 'path';
 import { expect, assert } from 'chai';
 import * as sinon from 'sinon';
@@ -130,7 +129,7 @@ describe('execCmd (sync)', () => {
     expect(result.jsonOutput).to.deep.equal(undefined);
     expect(result.jsonError).to.be.an('Error');
     expect(result.jsonError?.name).to.equal('JsonParseError');
-    expect(result.jsonError?.message).to.equal(`Parse error in file unknown on line 1${EOL}try JSON parsing this`);
+    expect(result.jsonError?.message).to.match(/Parse error in file unknown on line 1\n\r?try JSON parsing this/);
   });
 
   it('should override shell default', () => {
@@ -249,7 +248,7 @@ describe('execCmd (async)', () => {
     expect(result.jsonOutput).to.deep.equal(undefined);
     expect(result.jsonError).to.be.an('Error');
     expect(result.jsonError?.name).to.equal('JsonParseError');
-    expect(result.jsonError?.message).to.equal(`Parse error in file unknown on line 1${EOL}try JSON parsing this`);
+    expect(result.jsonError?.message).to.match(/Parse error in file unknown on line 1\n\r?try JSON parsing this/);
   });
 
   it('should override shell default', async () => {

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -29,11 +29,12 @@ describe('execCmd (sync)', () => {
   });
 
   it('should default to bin/run executable', () => {
+    const binPath = join('bin', 'run');
     sandbox.stub(fs, 'fileExistsSync').returns(true);
     const shellString = new ShellString(JSON.stringify(output));
     const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
     execCmd(cmd);
-    expect(execStub.args[0][0]).to.equal(`bin/run ${cmd}`);
+    expect(execStub.args[0][0]).to.equal(`${binPath} ${cmd}`);
   });
 
   it('should accept valid sfdx path in env var', () => {
@@ -160,11 +161,12 @@ describe('execCmd (async)', () => {
   });
 
   it('should default to bin/run executable', async () => {
+    const binPath = join('bin', 'run');
     sandbox.stub(fs, 'fileExistsSync').returns(true);
     const shellString = new ShellString(JSON.stringify(output));
     const execStub = stubMethod(sandbox, shelljs, 'exec').yields(0, shellString, '');
     await execCmd(cmd, { async: true });
-    expect(execStub.args[0][0]).to.equal(`bin/run ${cmd}`);
+    expect(execStub.args[0][0]).to.equal(`${binPath} ${cmd}`);
   });
 
   it('should accept valid sfdx path in env var', async () => {


### PR DESCRIPTION
Use same platforms definitions as other plugins for node version selection.