### PR TITLE
fix: consider --wait flag and increase default timeout

### DIFF
--- a/messages/exec_cmd.md
+++ b/messages/exec_cmd.md
@@ -1,3 +1,7 @@
 # waitTimeNegative
 
-The given wait time on the command, "%s", cannot be negative.
+The wait time on the command, "%s", cannot be negative.
+
+# callTimeoutNegative
+
+The value for options.timeout, "%s", cannot be negative.

--- a/messages/exec_cmd.md
+++ b/messages/exec_cmd.md
@@ -1,0 +1,3 @@
+# waitTimeNegative
+
+The given wait time on the command, "%s", cannot be negative.

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "!lib/**/*.map"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.20.1",
-    "@salesforce/kit": "^1.5.42",
-    "@salesforce/ts-types": "^1.5.17",
+    "@salesforce/core": "^3.30.2",
+    "@salesforce/kit": "^1.6.0",
+    "@salesforce/ts-types": "^1.5.21",
     "@types/shelljs": "^0.8.11",
     "archiver": "^5.2.0",
     "debug": "^4.3.1",

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -252,7 +252,7 @@ const execCmdAsync = async <T extends ExecCmdResult, U = Collection>(
  *
  * Option defaults:
  *    1. `cwd` = process.cwd()
- *    2. `timeout` = 300000 (5 minutes)
+ *    2. `timeout` = 1800000 (30 minutes)
  *    3. `env` = process.env
  *    4. `silent` = true (child process output not written to the console)
  *
@@ -280,7 +280,7 @@ export function execCmd<T = Collection>(
  *
  * Option defaults:
  *    1. `cwd` = process.cwd()
- *    2. `timeout` = 300000 (5 minutes)
+ *    2. `timeout` = 1800000 (30 minutes)
  *    3. `env` = process.env
  *    4. `silent` = true (child process output not written to the console)
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 export * from './genUniqueString';
-export * from './execCmd';
+export { ExecCmdOptions, ExecCmdResult, SfdxExecCmdResult, SfExecCmdResult, execCmd } from './execCmd';
 export { prepareForAuthUrl, prepareForJwt } from './hubAuth';
 export * from './testProject';
 export * from './testSession';

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -288,50 +288,56 @@ describe('execCmd (async)', () => {
   });
 });
 describe('getWaitTime', () => {
+  const FORTY_TWO_IN_MILLISECONDS = Duration.minutes(42).milliseconds;
+  const THIRTY_IN_MILLISECONDS = Duration.minutes(30).milliseconds;
+  const FIVE_IN_MILLISECONDS = Duration.minutes(5).milliseconds;
+
   it('should return a the default timeout', () => {
     const waitTime = getWaitTime('foo');
-    expect(waitTime).to.be.to.equal(Duration.minutes(30).milliseconds);
+    expect(waitTime).to.be.to.equal(THIRTY_IN_MILLISECONDS);
   });
-  it('should return timeout of 5 minutes', () => {
+  it('should return timeout of 5 minutes (in milliseconds) with flag --wait=5', () => {
     const waitTime = getWaitTime('foo --wait 5');
-    expect(waitTime).to.be.to.equal(Duration.minutes(5).milliseconds);
+    expect(waitTime).to.be.to.equal(FIVE_IN_MILLISECONDS);
   });
-  it('should return timeout of 5 minutes with flag --wait=5', () => {
+  it(`should return timeout of ${FORTY_TWO_IN_MILLISECONDS} with options.timeout = ${FORTY_TWO_IN_MILLISECONDS}`, () => {
     const waitTime = getWaitTime('foo --wait 5');
-    expect(waitTime).to.be.to.equal(Duration.minutes(5).milliseconds);
+    expect(waitTime).to.be.to.equal(FIVE_IN_MILLISECONDS);
   });
   it('should throw with negative wait', () => {
     // eslint-disable-next-line no-unused-expressions
-    expect(() => getWaitTime('foo --wait -42')).to.throw(
-      /The given wait time on the command, "-42", cannot be negative./
-    );
+    expect(() => getWaitTime('foo --wait -42')).to.throw(/The wait time on the command, "-42", cannot be negative./);
+  });
+  it('should throw with negative options.timeout', () => {
+    // eslint-disable-next-line no-unused-expressions
+    expect(() => getWaitTime('foo', -42)).to.throw(/The value for options.timeout, "-42", cannot be negative./);
   });
   it('should return command wait using short flag -w 42', () => {
     const waitTime = getWaitTime('foo -w42');
-    expect(waitTime).to.be.to.equal(Duration.minutes(42).milliseconds);
+    expect(waitTime).to.be.to.equal(FORTY_TWO_IN_MILLISECONDS);
   });
   it('should return command wait using short flag -w=42', () => {
     const waitTime = getWaitTime('foo -w=42');
-    expect(waitTime).to.be.to.equal(Duration.minutes(42).milliseconds);
+    expect(waitTime).to.be.to.equal(FORTY_TWO_IN_MILLISECONDS);
   });
   it('should return command wait using short flag with lots of spaces -w                              42', () => {
     const waitTime = getWaitTime('foo -w                              42');
-    expect(waitTime).to.be.to.equal(Duration.minutes(42).milliseconds);
+    expect(waitTime).to.be.to.equal(FORTY_TWO_IN_MILLISECONDS);
   });
   it('should return command default wait when wait flag has no value -w', () => {
     const waitTime = getWaitTime('foo -w');
-    expect(waitTime).to.be.to.equal(Duration.minutes(30).milliseconds);
+    expect(waitTime).to.be.to.equal(THIRTY_IN_MILLISECONDS);
   });
   it('should return timeout of 5 minutes when other parameters present', () => {
     const waitTime = getWaitTime('foo --baz --wait 5 --foo bar');
-    expect(waitTime).to.be.to.equal(Duration.minutes(5).milliseconds);
+    expect(waitTime).to.be.to.equal(FIVE_IN_MILLISECONDS);
   });
   it('should return timeout of 5 minutes when wait followed by numeric varargs', () => {
     const waitTime = getWaitTime('foo --baz --wait 5 123456');
-    expect(waitTime).to.be.to.equal(Duration.minutes(5).milliseconds);
+    expect(waitTime).to.be.to.equal(FIVE_IN_MILLISECONDS);
   });
   it('should return default timeout of 30 minutes when wait value is not numeric', () => {
     const waitTime = getWaitTime('foo --baz --wait forever');
-    expect(waitTime).to.be.to.equal(Duration.minutes(30).milliseconds);
+    expect(waitTime).to.be.to.equal(THIRTY_IN_MILLISECONDS);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,10 +575,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@^3.20.1":
-  version "3.26.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.26.2.tgz#94b361bd62967feb3eedc624fc6cf444e7347f84"
-  integrity sha512-GDrho8jbh1UDjcsYRRUzhNv4KUsMcBtux/yEqB2ycvHXhjVnrNkJcl99KESiU1eZMl2DGZEE1IO8yxnb2rSvgg==
+"@salesforce/core@^3.30.2":
+  version "3.30.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.30.2.tgz#fe7bd430e98b358003cf8892a753aaee88e3fd7f"
+  integrity sha512-MSDCbml/HOF8ZIMnYBQLnilXRTxOLnE8EJdCnO9XjIwMG8x9mVvn7EQEMxAS4G+e5oqXfpMtgxEN1fFJY/dbcA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.41"
@@ -643,7 +643,7 @@
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.5.41", "@salesforce/kit@^1.5.42":
+"@salesforce/kit@^1.5.41", "@salesforce/kit@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.6.0.tgz#0305dea2c9847d4b08068c4a9d436da5c9a5ce5e"
   integrity sha512-8VZvWYl61jBaUIqo+pNoDvVqaZKPmqauvkhJHvcr/+D7+EXsjne9PDMggy5mNQJvonD6iegR/h3BqcWrppSaeQ==
@@ -671,10 +671,10 @@
     sinon "^5.1.1"
     tslib "^2.2.0"
 
-"@salesforce/ts-types@^1.5.17", "@salesforce/ts-types@^1.5.20":
-  version "1.5.20"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.5.20.tgz#f6875a710ceca48223b240026a14af6d3b39882f"
-  integrity sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==
+"@salesforce/ts-types@^1.5.20", "@salesforce/ts-types@^1.5.21":
+  version "1.5.21"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.5.21.tgz#e62784872f0e74bf4ae13381dc58aa4644ee2df3"
+  integrity sha512-qG8r8WOzqpFOHaH3EGU3IwGrY/pSv9NQp4B0wGxOuPDBbraXVvd3KhWVStxaLGKBkJClJ7/+t+iCSP82sEiGcg==
   dependencies:
     tslib "^2.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3799,14 +3799,7 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^5.1.0:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==


### PR DESCRIPTION
@W-11763414@

Determines the execCmd timeout value using the following logic:
 1. Examine the command to be executed and determine if it contains a `--wait` param.
 2. If `--wait` param is present, use the value as the timeout.
 3. If `--wait` param is not present, use the value from the `callTimeout` (defaults to 30 minutes in millis) param.
 4. Neither `--wait` param nor `callTimeout` param can be negative.