### PR TITLE
feat!: v3 changes

### DIFF
--- a/samples/TestSession.sample10.nut.ts
+++ b/samples/TestSession.sample10.nut.ts
@@ -1,6 +1,5 @@
 import { execCmd } from '../src/execCmd';
 import { TestSession } from '../src/testSession';
-import { getString } from '@salesforce/ts-types';
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -10,12 +9,12 @@ describe('TestSession', () => {
       project: {
         name: 'MyTestProject',
       },
-      setupCommands: ['sfdx force:org:create edition=Developer'],
+      scratchOrgs: [{ edition: 'developer', config: 'config/project-scratch-def.json' }],
     });
   });
 
   it('using testkit to run commands with an org', () => {
-    const username = getString(testSession.setup[0], 'result.username');
+    const username = [...testSession.orgs.keys()][0];
     execCmd(`force:source:deploy -x package.xml -u ${username}`, { ensureExitCode: 0 });
   });
 

--- a/samples/TestSession.sample11.nut.ts
+++ b/samples/TestSession.sample11.nut.ts
@@ -1,7 +1,6 @@
 import { execCmd } from '../src/execCmd';
 import { TestSession } from '../src/testSession';
 import { TestProject } from '../src/testProject';
-import { getString } from '@salesforce/ts-types';
 import * as path from 'path';
 
 describe('TestSession', () => {
@@ -12,7 +11,7 @@ describe('TestSession', () => {
       project: {
         sourceDir: path.join(process.cwd(), 'localTestProj'),
       },
-      setupCommands: ['sfdx force:org:create -f config/project-scratch-def.json'],
+      scratchOrgs: [{ executable: 'sfdx', config: 'config/project-scratch-def.json' }],
     });
   });
 
@@ -26,7 +25,7 @@ describe('TestSession', () => {
       name: 'project2',
     });
     testSession.stubCwd(project2.dir);
-    const username = getString(testSession.setup[0], 'result.username');
+    const username = [...testSession.orgs.keys()][0];
     execCmd(`force:source:pull -u ${username}`);
   });
 

--- a/samples/TestSession.sample9.nut.ts
+++ b/samples/TestSession.sample9.nut.ts
@@ -1,6 +1,5 @@
 import { execCmd } from '../src/execCmd';
 import { TestSession } from '../src/testSession';
-import { getString } from '@salesforce/ts-types';
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -10,12 +9,14 @@ describe('TestSession', () => {
       project: {
         name: 'MyTestProject',
       },
-      setupCommands: ['sfdx force:org:create edition=Developer', 'sfdx force:source:push'],
+      scratchOrgs: [{ executable: 'sfdx', edition: 'developer' }],
     });
+
+    execCmd('force:source:push', { cli: 'sfdx' });
   });
 
   it('using testkit to run commands with an org', () => {
-    const username = getString(testSession.setup[0], 'result.username');
+    const username = [...testSession.orgs.keys()][0];
     execCmd(`user:create -u ${username}`, { ensureExitCode: 0 });
   });
 

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -19,34 +19,41 @@ import stripAnsi = require('strip-ansi');
 
 type Collection = Record<string, AnyJson> | Array<Record<string, AnyJson>>;
 
-export interface ExecCmdOptions extends ExecOptions {
+type CLI = 'inherit' | 'sfdx' | 'sf';
+
+type BaseExecOptions = {
   /**
    * Throws if this exit code is not returned by the child process.
    */
   ensureExitCode?: number;
 
   /**
-   * The base CLI that the plugin is used in. This is used primarily for changing the behavior
-   * of JSON parsing and types.
+   * The executable that should be used for execCmd.
+   * - inherit uses TESTKIT_EXECUTABLE_PATH to determine the executable. If it's not set it defaults to the local bin/dev
+   * - sfdx refers to the globally installed sfdx executable
+   * - sf refers to the globally installed sfdx executable
    */
-  cli?: 'sfdx' | 'sf';
+  cli?: CLI;
+};
 
+export type ExecCmdOptions = ExecOptions & BaseExecOptions;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExcludeMethods<T> = Pick<T, NonNullable<{ [K in keyof T]: T[K] extends (_: any) => any ? never : K }[keyof T]>>;
+
+type JsonOutput<T extends Collection> = { status: number; result: T } & Partial<ExcludeMethods<SfError>>;
+
+export interface ExecCmdResult<T extends Collection> {
   /**
-   * Answers to supply to any prompts. This does NOT work on windows.
+   * Command output parsed as JSON, if `--json` param present.
    */
-  answers?: string[];
-}
-
-export interface ExecCmdResult {
+  jsonOutput?: JsonOutput<T>;
   /**
    * Command output from the shell.
    *
    * @see https://www.npmjs.com/package/shelljs#execcommand--options--callback
    */
   shellOutput: ShellString;
-
-  jsonOutput?: unknown;
-
   /**
    * The JsonParseError if parsing failed.
    */
@@ -58,33 +65,13 @@ export interface ExecCmdResult {
   execCmdDuration: Duration;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ExcludeMethods<T> = Pick<T, NonNullable<{ [K in keyof T]: T[K] extends (_: any) => any ? never : K }[keyof T]>>;
-
-export interface SfdxExecCmdResult<T = Collection> extends ExecCmdResult {
-  /**
-   * Command output parsed as JSON, if `--json` param present.
-   */
-  jsonOutput?: { status: number; result: T } & Partial<ExcludeMethods<SfError>>;
-}
-
-export interface SfExecCmdResult<T = Collection> extends ExecCmdResult {
-  /**
-   * Command output parsed as JSON, if `--json` param present.
-   */
-  jsonOutput?: { status: number; result: T } & Partial<ExcludeMethods<SfError>>;
-}
-
-const DEFAULT_EXEC_OPTIONS: ExecCmdOptions = {
-  cli: 'sfdx',
-};
-
 const buildCmdOptions = (options?: ExecCmdOptions): ExecCmdOptions => {
-  const defaults: shelljs.ExecOptions = {
-    env: Object.assign({}, process.env),
+  const defaults: ExecCmdOptions = {
+    env: { ...process.env },
     cwd: process.cwd(),
     timeout: Duration.hours(1).milliseconds, // 1 hour
     silent: true,
+    cli: 'inherit',
   };
   const shellOverride = env.getString('TESTKIT_EXEC_SHELL');
   if (shellOverride) {
@@ -98,10 +85,10 @@ const hrtimeToMillisDuration = (hrTime: [number, number]) =>
   Duration.milliseconds(hrTime[0] * Duration.MILLIS_IN_SECONDS + hrTime[1] / 1e6);
 
 // Add JSON output if json flag is set
-const addJsonOutput = <T extends ExecCmdResult, U>(cmd: string, result: T): T => {
+const addJsonOutput = <T extends Collection>(cmd: string, result: ExecCmdResult<T>): ExecCmdResult<T> => {
   if (cmd.includes('--json')) {
     try {
-      result.jsonOutput = parseJson(stripAnsi(result.shellOutput.stdout)) as unknown as U;
+      result.jsonOutput = parseJson(stripAnsi(result.shellOutput.stdout)) as unknown as JsonOutput<T>;
     } catch (parseErr: unknown) {
       result.jsonError = parseErr as Error;
     }
@@ -122,21 +109,22 @@ const getExitCodeError = (cmd: string, expectedCode: number, output: ShellString
 };
 
 /**
- * Build a command string using an optional executable path for use by `execCmd`.
+ * Determine the executable path for use by `execCmd`.
  *
- * The executable preference order is:
- *    2. TESTKIT_EXECUTABLE_PATH env var
- *    3. `bin/dev` (default)
+ * If the cli is 'inherit', the executable preference order is:
+ *    1. TESTKIT_EXECUTABLE_PATH env var
+ *    2. `bin/dev` (default)
  *
- * @param cmdArgs The command name, args, and param as a string. E.g., `"force:user:create -a testuser1"`
  * @returns The command string with CLI executable. E.g., `"node_modules/bin/sfdx force:user:create -a testuser1"`
  */
-const buildCmd = (cmdArgs: string, options?: ExecCmdOptions): string => {
-  const debug = Debug('testkit:buildCmd');
+const determineExecutable = (cli: CLI = 'inherit'): string => {
+  const debug = Debug('testkit:determineExecutable');
 
   const bin =
-    env.getString('TESTKIT_EXECUTABLE_PATH') ??
-    pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev');
+    cli === 'inherit'
+      ? env.getString('TESTKIT_EXECUTABLE_PATH') ??
+        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev')
+      : cli;
   const which = shelljs.which(bin);
   let resolvedPath = pathResolve(bin);
 
@@ -147,16 +135,17 @@ const buildCmd = (cmdArgs: string, options?: ExecCmdOptions): string => {
     throw new Error(`Cannot find specified executable path: ${bin}`);
   }
 
-  debug(`Using executable path: ${bin}`);
   debug(`Resolved executable path: ${resolvedPath}`);
-  if (options?.answers && process.platform !== 'win32') {
-    return `printf "${options.answers.join('\\n')}" | ${bin} ${cmdArgs}`;
-  } else {
-    return `${bin} ${cmdArgs}`;
-  }
+  debug(`Using executable path: ${bin}`);
+  return bin;
 };
 
-const execCmdSync = <T extends ExecCmdResult, U = Collection>(cmd: string, options?: ExecCmdOptions): T => {
+const buildCmd = (cmdArgs: string, options?: ExecCmdOptions): string => {
+  const bin = determineExecutable(options?.cli);
+  return `${bin} ${cmdArgs}`;
+};
+
+const execCmdSync = <T extends Collection>(cmd: string, options?: ExecCmdOptions): ExecCmdResult<T> => {
   const debug = Debug('testkit:execCmd');
 
   // Add on the bin path
@@ -169,7 +158,7 @@ const execCmdSync = <T extends ExecCmdResult, U = Collection>(cmd: string, optio
   const result = {
     shellOutput: '' as ShellString,
     execCmdDuration: Duration.seconds(0),
-  } as T;
+  } as ExecCmdResult<T>;
 
   // Execute the command in a synchronous child process
   const startTime = process.hrtime();
@@ -183,19 +172,16 @@ const execCmdSync = <T extends ExecCmdResult, U = Collection>(cmd: string, optio
     throw getExitCodeError(cmd, cmdOptions.ensureExitCode, result.shellOutput);
   }
 
-  return addJsonOutput<T, U>(cmd, result);
+  return addJsonOutput<T>(cmd, result);
 };
 
-const execCmdAsync = async <T extends ExecCmdResult, U = Collection>(
-  cmd: string,
-  options: ExecCmdOptions
-): Promise<T> => {
+const execCmdAsync = async <T extends Collection>(cmd: string, options: ExecCmdOptions): Promise<ExecCmdResult<T>> => {
   const debug = Debug('testkit:execCmdAsync');
 
   // Add on the bin path
   cmd = buildCmd(cmd, options);
 
-  const resultPromise = new Promise<T>((resolve, reject) => {
+  const resultPromise = new Promise<ExecCmdResult<T>>((resolve, reject) => {
     const cmdOptions = buildCmdOptions(options);
 
     debug(`Running cmd: ${cmd}`);
@@ -215,12 +201,12 @@ const execCmdAsync = async <T extends ExecCmdResult, U = Collection>(
       const result = {
         shellOutput: new ShellString(stdout),
         execCmdDuration,
-      } as T;
+      } as ExecCmdResult<T>;
       result.shellOutput.code = code;
       result.shellOutput.stdout = stripAnsi(stdout);
       result.shellOutput.stderr = stripAnsi(stderr);
 
-      resolve(addJsonOutput<T, U>(cmd, result));
+      resolve(addJsonOutput<T>(cmd, result));
     };
 
     // Execute the command async in a child process
@@ -239,6 +225,7 @@ const execCmdAsync = async <T extends ExecCmdResult, U = Collection>(
  *    2. `timeout` = 3,600,000 (1 hour)
  *    3. `env` = process.env
  *    4. `silent` = true (child process output not written to the console)
+ *    5. `cli` = 'inherit' (use the TESTKIT_EXECUTABLE_PATH env var or `bin/dev` if not set for executing commands)
  *
  * Other defaults:
  *
@@ -249,60 +236,24 @@ const execCmdAsync = async <T extends ExecCmdResult, U = Collection>(
  * @param options The options used to run the command.
  * @returns The child process exit code, stdout, stderr, cmd run time, and the parsed JSON if `--json` param present.
  */
-export function execCmd<T = Collection>(
+export function execCmd<T extends Collection = Collection>(
   cmd: string,
-  options?: ExecCmdOptions & { async?: false; cli?: 'sfdx' }
-): SfdxExecCmdResult<T>;
+  options?: ExecCmdOptions & { async?: false }
+): ExecCmdResult<T>;
 
-export function execCmd<T = Collection>(
+export function execCmd<T extends Collection = Collection>(
   cmd: string,
-  options?: ExecCmdOptions & { async?: false; cli?: 'sf' }
-): SfExecCmdResult<T>;
+  options: ExecCmdOptions & { async: true }
+): Promise<ExecCmdResult<T>>;
 
-/**
- * Asynchronously execute a command with the provided options in a child process.
- *
- * Option defaults:
- *    1. `cwd` = process.cwd()
- *    2. `timeout` = 3,600,000 (1 hour)
- *    3. `env` = process.env
- *    4. `silent` = true (child process output not written to the console)
- *
- * Other defaults:
- *
- *    @see www.npmjs.com/package/shelljs#execcommand--options--callback
- *    @see www.nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
- *
- * @param cmd The command string to be executed by a child process.
- * @param options The options used to run the command.
- * @returns The child process exit code, stdout, stderr, cmd run time, and the parsed JSON if `--json` param present.
- */
-export function execCmd<T = Collection>(
+export function execCmd<T extends Collection = Collection>(
   cmd: string,
-  options: ExecCmdOptions & { async: true; cli?: 'sfdx' }
-): Promise<SfdxExecCmdResult<T>>;
-
-export function execCmd<T = Collection>(
-  cmd: string,
-  options: ExecCmdOptions & { async: true; cli?: 'sf' }
-): Promise<SfExecCmdResult<T>>;
-
-export function execCmd<T = Collection>(
-  cmd: string,
-  options: ExecCmdOptions = DEFAULT_EXEC_OPTIONS
-): SfdxExecCmdResult<T> | Promise<SfdxExecCmdResult<T>> | SfExecCmdResult<T> | Promise<SfExecCmdResult<T>> {
-  if (options.cli === 'sf') {
-    if (options.async) {
-      return execCmdAsync<SfExecCmdResult<T>, T>(cmd, options);
-    } else {
-      return execCmdSync<SfExecCmdResult<T>, T>(cmd, options);
-    }
+  options?: ExecCmdOptions
+): ExecCmdResult<T> | Promise<ExecCmdResult<T>> {
+  if (options?.async) {
+    return execCmdAsync<T>(cmd, options);
   } else {
-    if (options.async) {
-      return execCmdAsync<SfdxExecCmdResult<T>, T>(cmd, options);
-    } else {
-      return execCmdSync<SfdxExecCmdResult<T>, T>(cmd, options);
-    }
+    return execCmdSync<T>(cmd, options);
   }
 }
 
@@ -337,9 +288,7 @@ export type InteractiveCommandExecutionResult = {
   duration: Duration;
 };
 
-export type InteractiveCommandExecutionOptions = {
-  ensureExitCode?: number;
-} & SpawnOptionsWithoutStdio;
+export type InteractiveCommandExecutionOptions = BaseExecOptions & SpawnOptionsWithoutStdio;
 
 /**
  * A map of questions and answers to be used in an interactive command.
@@ -380,7 +329,7 @@ export async function execInteractiveCmd(
   const debug = Debug('testkit:execInteractiveCmd');
 
   return new Promise((resolve, reject) => {
-    const bin = buildCmd('').trim();
+    const bin = determineExecutable(options?.cli).trim();
     const startTime = process.hrtime();
     const opts =
       process.platform === 'win32'

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -67,7 +67,7 @@ export interface ExecCmdResult<T extends Collection> {
 
 const buildCmdOptions = (options?: ExecCmdOptions): ExecCmdOptions => {
   const defaults: ExecCmdOptions = {
-    env: { ...process.env },
+    env: { ...process.env, ...options?.env },
     cwd: process.cwd(),
     timeout: Duration.hours(1).milliseconds, // 1 hour
     silent: true,

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -17,9 +17,7 @@ import { ExecCallback, ExecOptions, ShellString } from 'shelljs';
 
 import stripAnsi = require('strip-ansi');
 
-type Collection = Record<string, AnyJson> | Array<Record<string, AnyJson>>;
-
-type CLI = 'inherit' | 'sfdx' | 'sf';
+export type CLI = 'inherit' | 'sfdx' | 'sf';
 
 type BaseExecOptions = {
   /**
@@ -41,9 +39,9 @@ export type ExecCmdOptions = ExecOptions & BaseExecOptions;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExcludeMethods<T> = Pick<T, NonNullable<{ [K in keyof T]: T[K] extends (_: any) => any ? never : K }[keyof T]>>;
 
-type JsonOutput<T extends Collection> = { status: number; result: T } & Partial<ExcludeMethods<SfError>>;
+type JsonOutput<T> = { status: number; result: T } & Partial<ExcludeMethods<SfError>>;
 
-export interface ExecCmdResult<T extends Collection> {
+export interface ExecCmdResult<T> {
   /**
    * Command output parsed as JSON, if `--json` param present.
    */
@@ -85,7 +83,7 @@ const hrtimeToMillisDuration = (hrTime: [number, number]) =>
   Duration.milliseconds(hrTime[0] * Duration.MILLIS_IN_SECONDS + hrTime[1] / 1e6);
 
 // Add JSON output if json flag is set
-const addJsonOutput = <T extends Collection>(cmd: string, result: ExecCmdResult<T>): ExecCmdResult<T> => {
+const addJsonOutput = <T>(cmd: string, result: ExecCmdResult<T>): ExecCmdResult<T> => {
   if (cmd.includes('--json')) {
     try {
       result.jsonOutput = parseJson(stripAnsi(result.shellOutput.stdout)) as unknown as JsonOutput<T>;
@@ -145,7 +143,7 @@ const buildCmd = (cmdArgs: string, options?: ExecCmdOptions): string => {
   return `${bin} ${cmdArgs}`;
 };
 
-const execCmdSync = <T extends Collection>(cmd: string, options?: ExecCmdOptions): ExecCmdResult<T> => {
+const execCmdSync = <T>(cmd: string, options?: ExecCmdOptions): ExecCmdResult<T> => {
   const debug = Debug('testkit:execCmd');
 
   // Add on the bin path
@@ -175,7 +173,7 @@ const execCmdSync = <T extends Collection>(cmd: string, options?: ExecCmdOptions
   return addJsonOutput<T>(cmd, result);
 };
 
-const execCmdAsync = async <T extends Collection>(cmd: string, options: ExecCmdOptions): Promise<ExecCmdResult<T>> => {
+const execCmdAsync = async <T>(cmd: string, options: ExecCmdOptions): Promise<ExecCmdResult<T>> => {
   const debug = Debug('testkit:execCmdAsync');
 
   // Add on the bin path
@@ -236,17 +234,11 @@ const execCmdAsync = async <T extends Collection>(cmd: string, options: ExecCmdO
  * @param options The options used to run the command.
  * @returns The child process exit code, stdout, stderr, cmd run time, and the parsed JSON if `--json` param present.
  */
-export function execCmd<T extends Collection = Collection>(
-  cmd: string,
-  options?: ExecCmdOptions & { async?: false }
-): ExecCmdResult<T>;
+export function execCmd<T = AnyJson>(cmd: string, options?: ExecCmdOptions & { async?: false }): ExecCmdResult<T>;
 
-export function execCmd<T extends Collection = Collection>(
-  cmd: string,
-  options: ExecCmdOptions & { async: true }
-): Promise<ExecCmdResult<T>>;
+export function execCmd<T = AnyJson>(cmd: string, options: ExecCmdOptions & { async: true }): Promise<ExecCmdResult<T>>;
 
-export function execCmd<T extends Collection = Collection>(
+export function execCmd<T = AnyJson>(
   cmd: string,
   options?: ExecCmdOptions
 ): ExecCmdResult<T> | Promise<ExecCmdResult<T>> {

--- a/src/hubAuth.ts
+++ b/src/hubAuth.ts
@@ -124,7 +124,7 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
   logger('no hub configured');
 };
 
-const getAuthStrategy = (): DevhubAuthStrategy => {
+export const getAuthStrategy = (): DevhubAuthStrategy => {
   if (
     env.getString('TESTKIT_JWT_CLIENT_ID') &&
     env.getString('TESTKIT_HUB_USERNAME') &&
@@ -156,9 +156,7 @@ const getAuthStrategy = (): DevhubAuthStrategy => {
  *
  */
 export const transferExistingAuthToEnv = (authStrategy: DevhubAuthStrategy): void => {
-  const strategy = authStrategy === DevhubAuthStrategy.AUTO ? getAuthStrategy() : authStrategy;
-  // nothing to do if the variables are already provided
-  if (strategy !== DevhubAuthStrategy.REUSE) return;
+  if (authStrategy !== DevhubAuthStrategy.REUSE) return;
 
   const logger = debug('testkit:transferExistingAuthToEnv');
   const devhub = env.getString('TESTKIT_HUB_USERNAME', '');

--- a/src/hubAuth.ts
+++ b/src/hubAuth.ts
@@ -12,13 +12,7 @@ import { debug } from 'debug';
 import { AuthFields } from '@salesforce/core';
 import { env } from '@salesforce/kit';
 
-export enum DevhubAuthStrategy {
-  AUTO = 'AUTO',
-  JWT = 'JWT',
-  AUTH_URL = 'AUTH_URL',
-  REUSE = 'REUSE',
-  NONE = 'NONE',
-}
+export type DevhubAuthStrategy = 'AUTO' | 'JWT' | 'AUTH_URL' | 'REUSE' | 'NONE';
 
 const DEFAULT_INSTANCE_URL = 'https://login.salesforce.com';
 
@@ -82,7 +76,7 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
     execOpts.shell = shellOverride;
   }
 
-  if (authStrategy === DevhubAuthStrategy.JWT) {
+  if (authStrategy === 'JWT') {
     logger('trying jwt auth');
     const jwtKey = prepareForJwt(homeDir);
 
@@ -104,7 +98,7 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
     }
     return;
   }
-  if (authStrategy === DevhubAuthStrategy.AUTH_URL) {
+  if (authStrategy === 'AUTH_URL') {
     logger('trying to authenticate with AuthUrl');
 
     const tmpUrl = prepareForAuthUrl(homeDir);
@@ -130,17 +124,17 @@ export const getAuthStrategy = (): DevhubAuthStrategy => {
     env.getString('TESTKIT_HUB_USERNAME') &&
     env.getString('TESTKIT_JWT_KEY')
   ) {
-    return DevhubAuthStrategy.JWT;
+    return 'JWT';
   }
   // you provided a username but not an auth url, so you must already have an auth that you want to re-use
   if (env.getString('TESTKIT_HUB_USERNAME') && !env.getString('TESTKIT_AUTH_URL')) {
-    return DevhubAuthStrategy.REUSE;
+    return 'REUSE';
   }
   // auth url alone
   if (env.getString('TESTKIT_AUTH_URL')) {
-    return DevhubAuthStrategy.AUTH_URL;
+    return 'AUTH_URL';
   }
-  return DevhubAuthStrategy.NONE;
+  return 'NONE';
 };
 
 /**
@@ -156,7 +150,7 @@ export const getAuthStrategy = (): DevhubAuthStrategy => {
  *
  */
 export const transferExistingAuthToEnv = (authStrategy: DevhubAuthStrategy): void => {
-  if (authStrategy !== DevhubAuthStrategy.REUSE) return;
+  if (authStrategy !== 'REUSE') return;
 
   const logger = debug('testkit:transferExistingAuthToEnv');
   const devhub = env.getString('TESTKIT_HUB_USERNAME', '');

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -17,7 +17,7 @@ import { genUniqueString } from './genUniqueString';
 import { zipDir } from './zip';
 
 import { TestProject, TestProjectOptions } from './testProject';
-import { AuthStrategy, testkitHubAuth, transferExistingAuthToEnv } from './hubAuth';
+import { DevhubAuthStrategy, getAuthStrategy, testkitHubAuth, transferExistingAuthToEnv } from './hubAuth';
 
 export interface TestSessionOptions {
   /**
@@ -40,7 +40,7 @@ export interface TestSessionOptions {
   /**
    * The preferred auth method to use
    */
-  authStrategy?: keyof typeof AuthStrategy;
+  devhubAuthStrategy?: DevhubAuthStrategy;
 
   /**
    * The number of times to retry the setupCommands after the initial attempt if it fails. Will be overridden by TESTKIT_SETUP_RETRIES environment variable.
@@ -147,8 +147,11 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
       JSON.stringify(JSON.parse(JSON.stringify(this.options)))
     );
 
-    const authStrategy = this.options.authStrategy ? AuthStrategy[this.options.authStrategy] : undefined;
-    // have to grab this before we change the home
+    const authStrategy =
+      !this.options.devhubAuthStrategy || this.options.devhubAuthStrategy === DevhubAuthStrategy.AUTO
+        ? getAuthStrategy()
+        : this.options.devhubAuthStrategy;
+
     transferExistingAuthToEnv(authStrategy);
 
     // Set the homedir used by this test, on the TestSession and the process

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -167,7 +167,7 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
     );
 
     const authStrategy =
-      !this.options.devhubAuthStrategy || this.options.devhubAuthStrategy === DevhubAuthStrategy.AUTO
+      !this.options.devhubAuthStrategy || this.options.devhubAuthStrategy === 'AUTO'
         ? getAuthStrategy()
         : this.options.devhubAuthStrategy;
 

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -260,6 +260,8 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
   private async deleteOrgs(): Promise<void> {
     if (!env.getString('TESTKIT_ORG_USERNAME') && this.orgs.size > 0) {
       for (const org of [...this.orgs.keys()]) {
+        if (org === 'default') continue;
+
         this.debug(`Deleting test org: ${org}`);
         const rv = shell.exec(`sf env delete scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
         this.orgs.delete(org);

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { RetryConfig } from 'ts-retry-promise';
 import { debug, Debugger } from 'debug';
 import { AsyncOptionalCreatable, Duration, env, parseJson, sleep } from '@salesforce/kit';
-import { AnyJson, getString, Optional } from '@salesforce/ts-types';
+import { Optional } from '@salesforce/ts-types';
 import { createSandbox, SinonStub } from 'sinon';
 import * as shell from 'shelljs';
 import stripAnsi = require('strip-ansi');
@@ -18,6 +18,19 @@ import { zipDir } from './zip';
 
 import { TestProject, TestProjectOptions } from './testProject';
 import { DevhubAuthStrategy, getAuthStrategy, testkitHubAuth, transferExistingAuthToEnv } from './hubAuth';
+
+type ScratchOrgConfig = {
+  executable: 'sfdx' | 'sf';
+  config: string;
+  duration?: number;
+  alias?: string;
+  setDefault?: string;
+};
+
+type OrgResult = {
+  username: string;
+  orgId: string;
+};
 
 export interface TestSessionOptions {
   /**
@@ -31,11 +44,11 @@ export interface TestSessionOptions {
   project?: TestProjectOptions;
 
   /**
-   * Commands to run as setup for tests.  All must have exitCode == 0 or session
-   * creation will throw.  Any org:create commands run as setup commands will
-   * be deleted as part of `TestSession.clean()`.
+   * Scratch orgs to create as part of setup.  All must be created successfully or session
+   * create will throw.  Scratch orgs created as part of setup will be deleted as part of
+   * `TestSession.clean()`.
    */
-  setupCommands?: string[];
+  scratchOrgs?: ScratchOrgConfig[];
 
   /**
    * The preferred auth method to use
@@ -80,7 +93,6 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
   public dir: string;
   public homeDir: string;
   public project?: TestProject;
-  public setup?: AnyJson[] | shell.ShellString;
 
   // this is stored on the class so that tests can set it to something much lower than default
   public rmRetryConfig: Partial<RetryConfig<void>> = { retries: 12, delay: 5000 };
@@ -90,8 +102,8 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
   private overriddenDir?: string;
   private sandbox = createSandbox();
-  private orgs: string[] = [];
-  private setupRetries: number;
+  private orgs: Record<string, OrgResult> = {};
+  private retries: number;
   private zipDir: typeof zipDir;
   private options: TestSessionOptions;
   private shelljsExecOptions: shell.ExecOptions = {
@@ -106,7 +118,7 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
     this.createdDate = new Date();
     this.id = genUniqueString(`${this.createdDate.valueOf()}%s`);
-    this.setupRetries = env.getNumber('TESTKIT_SETUP_RETRIES', this.options.retries) || 0;
+    this.retries = env.getNumber('TESTKIT_SETUP_RETRIES', this.options.retries) || 0;
 
     const shellOverride = env.getString('TESTKIT_EXEC_SHELL');
     if (shellOverride) {
@@ -223,14 +235,15 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
   protected async init(): Promise<void> {
     // Run all setup commands
-    await this.setupCommands(this.options.setupCommands);
+    await this.createOrgs(this.options.scratchOrgs);
 
     this.debug('Created testkit session:');
     this.debug(`  ID: ${this.id}`);
     this.debug(`  Created Date: ${this.createdDate}`);
     this.debug(`  Dir: ${this.dir}`);
     this.debug(`  Home Dir: ${this.homeDir}`);
-    if (this.orgs?.length) {
+    if (this.orgs) {
+      // TODO: test formatting on this
       this.debug('  Orgs: ', this.orgs);
     }
     if (this.project) {
@@ -240,11 +253,11 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
   private async deleteOrgs(): Promise<void> {
     if (!env.getString('TESTKIT_ORG_USERNAME') && this.orgs?.length) {
-      const orgs = this.orgs.slice();
+      const orgs = Object.keys(this.orgs);
       for (const org of orgs) {
         this.debug(`Deleting test org: ${org}`);
-        const rv = shell.exec(`sfdx force:org:delete -u ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
-        this.orgs = this.orgs.filter((o) => o !== org);
+        const rv = shell.exec(`sf env delete scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
+        delete this.orgs[org];
         if (rv.code !== 0) {
           // Must still delete the session dir if org:delete fails
           await this.rmSessionDir();
@@ -266,65 +279,52 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
   // Executes commands and keeps track of any orgs created.
   // Throws if any commands return a non-zero exitCode.
-  private async setupCommands(cmds?: string[]): Promise<void> {
+  private async createOrgs(orgs: ScratchOrgConfig[] = []): Promise<void> {
     const dbug = debug('testkit:setupCommands');
     const setup = () => {
-      if (cmds) {
-        this.setup = [];
-
-        for (let cmd of cmds) {
-          if (cmd.includes('org:create')) {
-            // Don't create orgs if we are supposed to reuse one from the env
-            const org = env.getString('TESTKIT_ORG_USERNAME');
-            if (org) {
-              dbug(`Not creating a new org. Reusing TESTKIT_ORG_USERNAME of: ${org}`);
-              this.setup.push({ result: { username: org } });
-              continue;
-            }
-          }
-
-          // Detect when running sfdx cli commands
-          if (cmd.split(' ')[0].includes('sfdx')) {
-            if (!shell.which('sfdx')) {
-              throw new Error('sfdx executable not found for running sfdx setup commands');
-            }
-            // Add the json flag if it looks like an sfdx command so we can return
-            // parsed json in the command return.
-            if (!cmd.includes('--json')) {
-              cmd += ' --json';
-            }
-          }
-
-          const rv = shell.exec(cmd, this.shelljsExecOptions) as shell.ShellString;
-          rv.stdout = stripAnsi(rv.stdout);
-          rv.stderr = stripAnsi(rv.stderr);
-          if (rv.code !== 0) {
-            const io = cmd.includes('--json') ? rv.stdout : rv.stderr;
-            throw Error(`Setup command ${cmd} failed due to: ${io}`);
-          }
-          dbug(`Output for setup cmd ${cmd} is:\n${rv.stdout}`);
-
-          // Automatically parse json results
-          if (cmd.includes('--json')) {
-            try {
-              const jsonOutput = parseJson(rv.stdout);
-              // keep track of all org creates
-              if (cmd.includes('org:create')) {
-                const username = getString(jsonOutput, 'result.username');
-                if (username) {
-                  dbug(`Saving org username: ${username} from ${cmd}`);
-                  this.orgs.push(username);
-                }
-              }
-              this.setup.push(jsonOutput);
-            } catch (err: unknown) {
-              dbug(`Failed command output JSON parsing due to:\n${(err as Error).message}`);
-              this.setup.push(rv);
-            }
-          } else {
-            this.setup.push(rv);
-          }
+      for (const org of orgs) {
+        // Don't create orgs if we are supposed to reuse one from the env
+        const orgUsername = env.getString('TESTKIT_ORG_USERNAME');
+        if (orgUsername) {
+          dbug(`Not creating a new org. Reusing TESTKIT_ORG_USERNAME of: ${org}`);
+          continue;
         }
+
+        const executable = org.executable ?? 'sf';
+
+        if (!shell.which(executable)) {
+          throw new Error(`${executable} executable not found for running sfdx setup commands`);
+        }
+
+        let baseCmd =
+          executable === 'sf'
+            ? `${executable} env create scratch -f ${org.config} --json`
+            : `${executable} force:org:create -f ${org.config} --json`;
+
+        if (org.alias) {
+          baseCmd += ` -a ${org.alias}`;
+        }
+
+        if (org.duration) {
+          baseCmd += executable === 'sf' ? ` -y ${org.duration}` : ` -d ${org.duration}`;
+        }
+
+        if (org.setDefault) {
+          baseCmd += executable === 'sf' ? ' -d' : ' -s';
+        }
+
+        const rv = shell.exec(baseCmd, this.shelljsExecOptions) as shell.ShellString;
+        rv.stdout = stripAnsi(rv.stdout);
+        rv.stderr = stripAnsi(rv.stderr);
+        if (rv.code !== 0) {
+          throw Error(`${org} failed due to: ${rv.stdout}`);
+        }
+        dbug(`Output for ${org} is:\n${rv.stdout}`);
+
+        const jsonOutput = parseJson(rv.stdout) as { status: number; result: { username: string; orgId: string } };
+        const username = jsonOutput.result.username;
+        dbug(`Saving org username: ${username} from ${org}`);
+        this.orgs[username] = { username, orgId: jsonOutput.result.orgId };
       }
     };
 
@@ -332,14 +332,14 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
     let completed = false;
     const timeout = new Duration(env.getNumber('TESTKIT_SETUP_RETRIES_TIMEOUT') ?? 5000, Duration.Unit.MILLISECONDS);
 
-    while (!completed && attempts <= this.setupRetries) {
+    while (!completed && attempts <= this.retries) {
       try {
-        dbug(`Executing setup commands (attempt ${attempts + 1} of ${this.setupRetries + 1})`);
+        dbug(`Executing org create(s) (attempt ${attempts + 1} of ${this.retries + 1})`);
         setup();
         completed = true;
       } catch (err) {
         attempts += 1;
-        if (attempts > this.setupRetries) {
+        if (attempts > this.retries) {
           throw err;
         }
         dbug(`Setup failed. waiting ${timeout.seconds} seconds before next attempt...`);

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -36,6 +36,7 @@ export type ScratchOrgConfig = {
     | 'partner-group'
     | 'partner-professional';
   username?: string;
+  wait?: number;
 };
 
 export interface TestSessionOptions {
@@ -330,6 +331,10 @@ export class TestSession extends AsyncOptionalCreatable<TestSessionOptions> {
 
         if (org.edition) {
           baseCmd += executable === 'sf' ? ` -e ${org.edition}` : ` edition=${org.edition}`;
+        }
+
+        if (org.wait) {
+          baseCmd += `-w ${org.wait}`;
         }
 
         const rv = shell.exec(baseCmd, this.shelljsExecOptions) as shell.ShellString;

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -36,6 +36,34 @@ describe('execCmd (sync)', () => {
     expect(execStub.args[0][0]).to.equal(`${binPath} ${cmd}`);
   });
 
+  it('should default to bin/dev executable when cli = inherit', () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev');
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
+    const shellString = new ShellString(JSON.stringify(output));
+    const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
+    execCmd(cmd, { cli: 'inherit' });
+    expect(execStub.args[0][0]).to.equal(`${binPath} ${cmd}`);
+  });
+
+  it('should default to sfdx when cli = sfdx', () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
+    const shellString = new ShellString(JSON.stringify(output));
+    const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
+    execCmd(cmd, { cli: 'sfdx' });
+    expect(execStub.args[0][0]).to.equal(`sfdx ${cmd}`);
+  });
+
+  it('should default to sf when cli = sf', () => {
+    sandbox.stub(fs, 'existsSync').returns(true);
+    sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
+    const shellString = new ShellString(JSON.stringify(output));
+    const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
+    execCmd(cmd, { cli: 'sf' });
+    expect(execStub.args[0][0]).to.equal(`sf ${cmd}`);
+  });
+
   it('should accept valid sfdx path in env var', () => {
     const binPath = join('sfdx-cli', 'bin', 'sfdx');
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -16,7 +16,8 @@ import { ShellString } from 'shelljs';
 import { spyMethod, stubMethod } from '@salesforce/ts-sinon';
 import { env } from '@salesforce/kit';
 import Sinon = require('sinon');
-import { TestSession } from '../../src/testSession';
+import { AuthFields } from '@salesforce/core';
+import { ScratchOrgConfig, TestSession } from '../../src/testSession';
 import { TestProject } from '../../src/testProject';
 
 describe('TestSession', () => {
@@ -49,7 +50,7 @@ describe('TestSession', () => {
       expect(session.dir).to.equal(path.join(cwd, `test_session_${session.id}`));
       expect(session.homeDir).to.equal(session.dir);
       expect(session.project).to.equal(undefined);
-      expect(session.setup).to.equal(undefined);
+      expect(session.orgs.size).to.equal(0);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
@@ -65,7 +66,7 @@ describe('TestSession', () => {
       expect(session.dir).to.equal(sessionDir);
       expect(session.homeDir).to.equal(session.dir);
       expect(session.project).to.equal(undefined);
-      expect(session.setup).to.equal(undefined);
+      expect(session.orgs.size).to.equal(0);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
@@ -87,7 +88,7 @@ describe('TestSession', () => {
       expect(session.dir).to.equal(sessionDir);
       expect(session.homeDir).to.equal(homedir);
       expect(session.project).to.equal(undefined);
-      expect(session.setup).to.equal(undefined);
+      expect(session.orgs.size).to.equal(0);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
@@ -111,7 +112,7 @@ describe('TestSession', () => {
       expect(session.project).to.be.instanceOf(TestProject);
       expect(session.project?.dir).to.equal(path.join(session.dir, testProjName));
       expect(stubCwdStub.firstCall.args[0]).to.equal(session.project?.dir);
-      expect(session.setup).to.equal(undefined);
+      expect(session.orgs.size).to.equal(0);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
@@ -141,49 +142,18 @@ describe('TestSession', () => {
       expect(session.homeDir).to.equal(homedir);
       expect(session.project).to.equal(undefined);
       expect(stubCwdStub.firstCall.args[0]).to.equal(projectDir);
-      expect(session.setup).to.equal(undefined);
+      expect(session.orgs.size).to.equal(0);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
     });
 
-    it('should create a session with setup commands', async () => {
-      stubMethod(sandbox, shelljs, 'which').returns(true);
-      const homedir = path.join('some', 'other', 'home');
-      const shellOverride = 'powershell.exe';
-      stubMethod(sandbox, env, 'getString')
-        .withArgs('TESTKIT_EXEC_SHELL')
-        .returns(shellOverride)
-        .withArgs('TESTKIT_HOMEDIR')
-        .returns(homedir);
-      const setupCommands = ['sfdx foo:bar -r testing'];
-      const execRv = { result: { donuts: 'yum' } };
-      const shellString = new ShellString(JSON.stringify(execRv));
-      shellString.code = 0;
-      const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
-
-      const session = await TestSession.create({ setupCommands });
-
-      expect(mkdirpStub.calledWith(session.dir)).to.equal(true);
-      expect(writeJsonStub.firstCall.args[0]).to.equal(path.join(session.dir, optionsFileName));
-      expect(session.id).to.be.a('string');
-      expect(session.createdDate).to.be.a('Date');
-      expect(session.dir).to.equal(path.join(cwd, `test_session_${session.id}`));
-      expect(session.homeDir).to.equal(homedir);
-      expect(session.project).to.equal(undefined);
-      expect(session.setup).to.deep.equal([execRv]);
-      expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
-      expect(execStub.firstCall.args[1]).to.have.property('shell', shellOverride);
-      expect(process.env.HOME).to.equal(session.homeDir);
-      expect(process.env.USERPROFILE).to.equal(session.homeDir);
-    });
-
-    it('should create a session with setup commands and retries', async () => {
+    it('should create a session with scratch orgs and retries', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
       // set retry timeout to 0 ms so that the test runs quickly
       process.env.TESTKIT_SETUP_RETRIES_TIMEOUT = '0';
       const retries = 2;
-      const setupCommands = ['sfdx foo:bar -r testing'];
-      const execRv = { result: { donuts: 'yum' } };
+      const username = 'hey@ho.org';
+      const execRv = { result: { username, authFields: { username, orgId: '12345' } } };
       const execStub = stubMethod(sandbox, shelljs, 'exec')
         .onCall(retries)
         .callsFake(() => {
@@ -197,25 +167,40 @@ describe('TestSession', () => {
           return shellString;
         });
       const sleepSpy = spyMethod(sandbox, TestSession.prototype, 'sleep');
-      const session = await TestSession.create({ setupCommands, retries });
+
+      const scratchOrgs = [{ executable: 'sf', config: 'config/project-scratch-def.json' }] as ScratchOrgConfig[];
+
+      const session = await TestSession.create({
+        scratchOrgs,
+        retries,
+      });
       // expect sleepSync to be called before every retry attempt
       expect(sleepSpy.callCount).to.equal(retries);
       // expect exec to be called on every retry attempt AND the initial attempt
-      expect(execStub.callCount).to.equal(setupCommands.length * (retries + 1));
-      expect(session.setup).to.deep.equal([execRv]);
-      expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
+      expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
+      expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
+      expect(execStub.firstCall.args[0]).to.equal('sf env create scratch -f config/project-scratch-def.json --json');
     });
 
-    it('should create a session with org creation setup commands', async () => {
+    it('should create a session with org creation', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const setupCommands = ['sfdx org:create -f config/project-scratch-def.json'];
       const username = 'hey@ho.org';
-      const execRv = { result: { username } };
+      const execRv = { result: { username, authFields: { username, orgId: '12345' } } };
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 0;
       const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
 
-      const session = await TestSession.create({ setupCommands });
+      const session = await TestSession.create({
+        scratchOrgs: [
+          {
+            executable: 'sf',
+            config: 'config/project-scratch-def.json',
+            alias: 'my-org',
+            setDefault: true,
+            duration: 1,
+          },
+        ],
+      });
 
       expect(mkdirpStub.calledWith(session.dir)).to.equal(true);
       expect(writeJsonStub.firstCall.args[0]).to.equal(path.join(session.dir, optionsFileName));
@@ -224,13 +209,12 @@ describe('TestSession', () => {
       expect(session.dir).to.equal(path.join(cwd, `test_session_${session.id}`));
       expect(session.homeDir).to.equal(session.dir);
       expect(session.project).to.equal(undefined);
-      expect(session.setup).to.deep.equal([execRv]);
-      expect(execStub.firstCall.args[0]).to.equal(`${setupCommands[0]} --json`);
+      expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
+      expect(execStub.firstCall.args[0]).to.equal(
+        'sf env create scratch -f config/project-scratch-def.json --json -a my-org -y 1 -d'
+      );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
-
-      // @ts-ignore session.orgs is private
-      expect(session.orgs).to.deep.equal([username]);
     });
 
     it('should create a session without org creation if TESTKIT_ORG_USERNAME is defined', async () => {
@@ -243,13 +227,15 @@ describe('TestSession', () => {
         .withArgs('TESTKIT_HOMEDIR')
         .returns(homedir);
       const username = 'hey@ho.org';
-      const setupCommands = ['sfdx org:create -f config/project-scratch-def.json'];
-      const execRv = { result: { username } };
+
+      const execRv = { result: { username, orgId: '12345' } };
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 0;
       const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
 
-      const session = await TestSession.create({ setupCommands });
+      const session = await TestSession.create({
+        scratchOrgs: [{ executable: 'sfdx', config: 'config/project-scratch-def.json' }],
+      });
 
       expect(mkdirpStub.calledWith(session.dir)).to.equal(true);
       expect(writeJsonStub.firstCall.args[0]).to.equal(path.join(session.dir, optionsFileName));
@@ -258,45 +244,44 @@ describe('TestSession', () => {
       expect(session.dir).to.equal(path.join(cwd, `test_session_${session.id}`));
       expect(session.homeDir).to.equal(homedir);
       expect(session.project).to.equal(undefined);
-      expect(session.setup).to.deep.equal([{ result: { username: overriddenUsername } }]);
+      expect(session.orgs.get(overriddenUsername)).to.deep.equal({ username: overriddenUsername });
       expect(execStub.called).to.equal(false);
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
-
-      // @ts-ignore session.orgs is private
-      expect(session.orgs).to.deep.equal([]);
     });
 
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const setupCommands = ['sfdx foo:bar -r testing'];
-      const expectedCmd = `${setupCommands[0]} --json`;
+      const expectedCmd = 'sf env create scratch -f config/project-scratch-def.json --json';
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;
       stubMethod(sandbox, shelljs, 'exec').returns(shellString);
 
       try {
-        await TestSession.create({ setupCommands });
+        await TestSession.create({
+          scratchOrgs: [{ executable: 'sf', config: 'config/project-scratch-def.json' }],
+        });
         assert(false, 'TestSession.create() should throw');
       } catch (err: unknown) {
-        expect((err as Error).message).to.equal(`Setup command ${expectedCmd} failed due to: ${shellString.stdout}`);
+        expect((err as Error).message).to.equal(`${expectedCmd} failed due to: ${shellString.stdout}`);
       }
     });
 
     it('should error if sfdx not found to run setup commands', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(null);
-      const setupCommands = ['sfdx foo:bar -r testing'];
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;
       stubMethod(sandbox, shelljs, 'exec').returns(shellString);
 
       try {
-        await TestSession.create({ setupCommands });
+        await TestSession.create({
+          scratchOrgs: [{ executable: 'sf', config: 'config/project-scratch-def.json' }],
+        });
         assert(false, 'TestSession.create() should throw');
       } catch (err: unknown) {
-        expect((err as Error).message).to.equal('sfdx executable not found for running sfdx setup commands');
+        expect((err as Error).message).to.equal('sf executable not found for creating scratch orgs');
       }
     });
   });
@@ -344,13 +329,13 @@ describe('TestSession', () => {
       execStub.returns(shellString);
       rmStub.returns(shellString);
       const username = 'me@my.org';
-      // @ts-ignore
-      session.orgs = [username];
+
+      session.orgs = new Map<string, AuthFields>().set(username, { username, orgId: '12345' });
 
       await session.clean();
 
       expect(restoreSpy.called).to.equal(true);
-      expect(execStub.firstCall.args[0]).to.equal(`sfdx force:org:delete -u ${username} -p`);
+      expect(execStub.firstCall.args[0]).to.equal(`sf env delete scratch -o ${username} -p`);
       expect(rmStub.firstCall.args[0]).to.equal(session.dir);
       expect(rmStub.firstCall.args[1]).to.deep.equal(rmOptions);
     });

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -179,7 +179,7 @@ describe('TestSession', () => {
       // expect exec to be called on every retry attempt AND the initial attempt
       expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
-      expect(execStub.firstCall.args[0]).to.equal('sf env create scratch -f config/project-scratch-def.json --json');
+      expect(execStub.firstCall.args[0]).to.equal('sf env create scratch --json -f config/project-scratch-def.json');
     });
 
     it('should create a session with org creation', async () => {
@@ -198,6 +198,7 @@ describe('TestSession', () => {
             alias: 'my-org',
             setDefault: true,
             duration: 1,
+            edition: 'developer',
           },
         ],
       });
@@ -210,8 +211,9 @@ describe('TestSession', () => {
       expect(session.homeDir).to.equal(session.dir);
       expect(session.project).to.equal(undefined);
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
+      expect(session.orgs.get('default')).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf env create scratch -f config/project-scratch-def.json --json -a my-org -y 1 -d'
+        'sf env create scratch --json -f config/project-scratch-def.json -a my-org -y 1 -d -e developer'
       );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
@@ -252,7 +254,7 @@ describe('TestSession', () => {
 
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const expectedCmd = 'sf env create scratch -f config/project-scratch-def.json --json';
+      const expectedCmd = 'sf env create scratch --json -f config/project-scratch-def.json';
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;

--- a/test/unit/zzhubAuth.test.ts
+++ b/test/unit/zzhubAuth.test.ts
@@ -19,7 +19,7 @@ import { AuthFields } from '@salesforce/core';
 import { Env, env } from '@salesforce/kit';
 import * as sinon from 'sinon';
 import * as shell from 'shelljs';
-import { DevhubAuthStrategy, prepareForAuthUrl, prepareForJwt, transferExistingAuthToEnv } from '../../src/hubAuth';
+import { prepareForAuthUrl, prepareForJwt, transferExistingAuthToEnv } from '../../src/hubAuth';
 
 const { expect } = chai;
 const tmp = os.tmpdir();
@@ -179,7 +179,7 @@ describe('hubAuth', () => {
         .withArgs(sinon.match.any)
         .returns(JSON.stringify(authFields));
       shellStub = stubMethod(sandbox, shell, 'exec').returns({});
-      transferExistingAuthToEnv(DevhubAuthStrategy.REUSE);
+      transferExistingAuthToEnv('REUSE');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,no-unused-expressions
       expect(shellStub.calledOnce).to.be.false;
       sandbox.restore();
@@ -197,7 +197,7 @@ describe('hubAuth', () => {
       shellStub = stubMethod(sandbox, shell, 'exec').returns(
         JSON.stringify({ result: { sfdxAuthUrl: sampleAuthData.sfdxAuthUrl } })
       );
-      transferExistingAuthToEnv(DevhubAuthStrategy.REUSE);
+      transferExistingAuthToEnv('REUSE');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,no-unused-expressions
       expect(shellStub.calledOnce).to.be.true;
       sandbox.restore();

--- a/test/unit/zzhubAuth.test.ts
+++ b/test/unit/zzhubAuth.test.ts
@@ -19,7 +19,7 @@ import { AuthFields } from '@salesforce/core';
 import { Env, env } from '@salesforce/kit';
 import * as sinon from 'sinon';
 import * as shell from 'shelljs';
-import { AuthStrategy, prepareForAuthUrl, prepareForJwt, transferExistingAuthToEnv } from '../../src/hubAuth';
+import { DevhubAuthStrategy, prepareForAuthUrl, prepareForJwt, transferExistingAuthToEnv } from '../../src/hubAuth';
 
 const { expect } = chai;
 const tmp = os.tmpdir();
@@ -179,7 +179,7 @@ describe('hubAuth', () => {
         .withArgs(sinon.match.any)
         .returns(JSON.stringify(authFields));
       shellStub = stubMethod(sandbox, shell, 'exec').returns({});
-      transferExistingAuthToEnv(AuthStrategy.REUSE);
+      transferExistingAuthToEnv(DevhubAuthStrategy.REUSE);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,no-unused-expressions
       expect(shellStub.calledOnce).to.be.false;
       sandbox.restore();
@@ -197,7 +197,7 @@ describe('hubAuth', () => {
       shellStub = stubMethod(sandbox, shell, 'exec').returns(
         JSON.stringify({ result: { sfdxAuthUrl: sampleAuthData.sfdxAuthUrl } })
       );
-      transferExistingAuthToEnv(AuthStrategy.REUSE);
+      transferExistingAuthToEnv(DevhubAuthStrategy.REUSE);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,no-unused-expressions
       expect(shellStub.calledOnce).to.be.true;
       sandbox.restore();


### PR DESCRIPTION
- Makes `cli` property on `execCmd` dictate which executable is used. 
  - `inherit`: use `TESTKIT_EXECUTABLE_PATH` or local executable if not set
  - `sfdx`: use `sfdx`
  - `sf`: use `sf`

- Renames `authStrategy` to `devhubAuthStrategy` and default to `NONE`
- Adds `AUTO` option to `devhubAuthStrategy` to replace v2's existing default (determine the method by which env vars are present)
- Removes `setupCommands` from `TestSession`
- Adds `scratchOrgs` option to `TestSession` and saves `AuthFields` to `TestSession.orgs`

    ```typescript
    const testSession = await TestSession.create({
      scratchOrgs: [{ edition: 'developer', config: 'config/project-scratch-def.json', setDefault: true }],
    });
    // if setDefault, then the default org will be accessible with the 'default' key. Otherwise, you can use the org's username to access its auth fields
    const authFields = testSession.orgs.get('default'); 
    execCmd(`force:source:deploy -x package.xml -u ${authFields.username}`, { ensureExitCode: 0 });
    ```

@W-11823386@