### PR TITLE
feat: add makeUxStubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "!lib/**/*.map"
   ],
   "dependencies": {
+    "@oclif/core": "^2.1.4",
     "@salesforce/core": "^3.33.1",
     "@salesforce/kit": "^1.8.0",
+    "@salesforce/sf-plugins-core": "^2.1.2",
     "@salesforce/ts-types": "^1.7.2",
     "@types/shelljs": "^0.8.11",
     "archiver": "^5.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,54 @@ export { prepareForAuthUrl, prepareForJwt } from './hubAuth';
 export * from './testProject';
 export * from './testSession';
 export { Duration } from '@salesforce/kit';
+
+import { SinonSandbox } from 'sinon';
+import { SfCommand, Ux } from '@salesforce/sf-plugins-core';
+import { ux } from '@oclif/core';
+import { Spinner } from '@salesforce/sf-plugins-core/lib/ux';
+
+export function makeUxStubs(sandbox: SinonSandbox) {
+  const startSpinner = sandbox.stub(Spinner.prototype, 'start');
+  const stopSpinner = sandbox.stub(Spinner.prototype, 'stop');
+  return {
+    SfCommand: {
+      log: sandbox.stub(SfCommand.prototype, 'log'),
+      logToStderr: sandbox.stub(SfCommand.prototype, 'logToStderr'),
+      logSuccess: sandbox.stub(SfCommand.prototype, 'logSuccess'),
+      logSensitive: sandbox.stub(SfCommand.prototype, 'logSensitive'),
+      info: sandbox.stub(SfCommand.prototype, 'info'),
+      warn: sandbox.stub(SfCommand.prototype, 'warn'),
+      table: sandbox.stub(SfCommand.prototype, 'table'),
+      url: sandbox.stub(SfCommand.prototype, 'url'),
+      styledHeader: sandbox.stub(SfCommand.prototype, 'styledHeader'),
+      styledObject: sandbox.stub(SfCommand.prototype, 'styledObject'),
+      styledJSON: sandbox.stub(SfCommand.prototype, 'styledJSON'),
+      startSpinner,
+      stopSpinner,
+    },
+    '@oclif/core': {
+      info: sandbox.stub(ux, 'info'),
+      log: sandbox.stub(ux, 'log'),
+      warn: sandbox.stub(ux, 'warn'),
+      annotation: sandbox.stub(ux, 'annotation'),
+      table: sandbox.stub(ux, 'table'),
+      url: sandbox.stub(ux, 'url'),
+      styledHeader: sandbox.stub(ux, 'styledHeader'),
+      styledObject: sandbox.stub(ux, 'styledObject'),
+      styledJSON: sandbox.stub(ux, 'styledJSON'),
+      startSpinner: sandbox.stub(ux.action, 'start'),
+      stopSpinner: sandbox.stub(ux.action, 'stop'),
+    },
+    Ux: {
+      log: sandbox.stub(Ux.prototype, 'log'),
+      warn: sandbox.stub(Ux.prototype, 'warn'),
+      table: sandbox.stub(Ux.prototype, 'table'),
+      url: sandbox.stub(Ux.prototype, 'url'),
+      styledHeader: sandbox.stub(Ux.prototype, 'styledHeader'),
+      styledObject: sandbox.stub(Ux.prototype, 'styledObject'),
+      styledJSON: sandbox.stub(Ux.prototype, 'styledJSON'),
+      startSpinner,
+      stopSpinner,
+    },
+  };
+}

--- a/test/unit/makeUxStubs.test.ts
+++ b/test/unit/makeUxStubs.test.ts
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SfCommand, Ux } from '@salesforce/sf-plugins-core';
+import { createSandbox, SinonSandbox } from 'sinon';
+import { ux as coreUx, Flags, Interfaces } from '@oclif/core';
+import { expect } from 'chai';
+import { makeUxStubs } from '../../src/index';
+
+const TABLE_DATA = Array.from({ length: 10 }).fill({ id: '123', name: 'foo', value: 'bar' }) as Array<
+  Record<string, unknown>
+>;
+const TABLE_COLUMNS = {
+  id: { header: 'ID' },
+  name: {},
+  value: { header: 'TEST' },
+};
+
+class Cmd extends SfCommand<void> {
+  public static flags = {
+    method: Flags.custom<'@oclif/core' | 'SfCommand' | 'Ux'>({
+      options: ['@oclif/core', 'SfCommand', 'Ux'],
+    })({
+      required: true,
+    }),
+    info: Flags.boolean(),
+    log: Flags.boolean(),
+    logSensitive: Flags.boolean(),
+    logSuccess: Flags.boolean(),
+    logToStderr: Flags.boolean(),
+    spinner: Flags.boolean(),
+    styledHeader: Flags.boolean(),
+    styledJSON: Flags.boolean(),
+    styledObject: Flags.boolean(),
+    table: Flags.boolean(),
+    url: Flags.boolean(),
+    warn: Flags.boolean(),
+  };
+
+  private flags!: Interfaces.InferredFlags<typeof Cmd.flags>;
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(Cmd);
+    this.flags = flags;
+
+    if (flags.info) this.runInfo();
+    if (flags.log) this.runLog();
+    if (flags.logSensitive) this.runLogSensitive();
+    if (flags.logSuccess) this.runLogSuccess();
+    if (flags.logToStderr) this.runLogToStderr();
+    if (flags.spinner) this.runSpinner();
+    if (flags.styledHeader) this.runStyledHeader();
+    if (flags.styledJSON) this.runStyledJSON();
+    if (flags.styledObject) this.runStyledObject();
+    if (flags.table) this.runTable();
+    if (flags.url) this.runUrl();
+    if (flags.warn) this.runWarn();
+  }
+
+  private runInfo(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.info('hello');
+        break;
+      case 'SfCommand':
+        this.info('hello');
+        break;
+      case 'Ux':
+        throw new Error('Ux.info is not implemented');
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+    this.info('hello');
+  }
+
+  private runLog(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.log('hello');
+        break;
+      case 'SfCommand':
+        this.log('hello');
+        break;
+      case 'Ux':
+        new Ux().log('hello');
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runLogSuccess(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        throw new Error('ux.logSuccess is not implemented');
+      case 'SfCommand':
+        this.logSuccess('hello');
+        break;
+      case 'Ux':
+        throw new Error('Ux.logSuccess is not implemented');
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runLogSensitive(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        throw new Error('ux.logSensitive is not implemented');
+      case 'SfCommand':
+        this.logSensitive('hello');
+        break;
+      case 'Ux':
+        throw new Error('Ux.logSensitive is not implemented');
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runLogToStderr(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        throw new Error('ux.logToStderr is not implemented');
+      case 'SfCommand':
+        this.logToStderr('hello');
+        break;
+      case 'Ux':
+        throw new Error('Ux.logToStderr is not implemented');
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runWarn(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.warn('hello');
+        break;
+      case 'SfCommand':
+        this.warn('hello');
+        break;
+      case 'Ux':
+        new Ux().warn('hello');
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runTable(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.table(TABLE_DATA, TABLE_COLUMNS);
+        break;
+      case 'SfCommand':
+        this.table(TABLE_DATA, TABLE_COLUMNS);
+        break;
+      case 'Ux':
+        new Ux().table(TABLE_DATA, TABLE_COLUMNS);
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runUrl(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.url('oclif', 'https://oclif.io');
+        break;
+      case 'SfCommand':
+        this.url('oclif', 'https://oclif.io');
+        break;
+      case 'Ux':
+        new Ux().url('oclif', 'https://oclif.io');
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runStyledHeader(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.styledHeader('hello');
+        break;
+      case 'SfCommand':
+        this.styledHeader('hello');
+        break;
+      case 'Ux':
+        new Ux().styledHeader('hello');
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runStyledObject(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.styledObject({ foo: 'bar' });
+        break;
+      case 'SfCommand':
+        this.styledObject({ foo: 'bar' });
+        break;
+      case 'Ux':
+        new Ux().styledObject({ foo: 'bar' });
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runStyledJSON(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.styledJSON({ foo: 'bar' });
+        break;
+      case 'SfCommand':
+        this.styledJSON({ foo: 'bar' });
+        break;
+      case 'Ux':
+        new Ux().styledJSON({ foo: 'bar' });
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+
+  private runSpinner(): void {
+    switch (this.flags.method) {
+      case '@oclif/core':
+        coreUx.action.start('starting spinner');
+        coreUx.action.stop('done');
+        break;
+      case 'SfCommand':
+        this.spinner.start('starting spinner');
+        this.spinner.stop('done');
+        break;
+      case 'Ux':
+        new Ux().spinner.start('starting spinner');
+        new Ux().spinner.stop('done');
+        break;
+      default:
+        throw new Error(`Invalid method: ${this.flags.method}`);
+    }
+  }
+}
+
+describe('makeUxStubs', () => {
+  let uxStubs: ReturnType<typeof makeUxStubs>;
+  let sandbox: SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    uxStubs = makeUxStubs(sandbox);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('@oclif/core ux utilities', () => {
+    it('should stub ux.info', () => {
+      coreUx.info('hello');
+      expect(uxStubs['@oclif/core'].info.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub ux.log', () => {
+      coreUx.log('hello');
+      expect(uxStubs['@oclif/core'].log.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub ux.warn', () => {
+      coreUx.warn('hello');
+      expect(uxStubs['@oclif/core'].warn.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub ux.annotation', () => {
+      coreUx.annotation('hello', 'world');
+      expect(uxStubs['@oclif/core'].annotation.firstCall.args).to.deep.equal(['hello', 'world']);
+    });
+
+    it('should stub ux.table', () => {
+      coreUx.table(TABLE_DATA, TABLE_COLUMNS);
+      expect(uxStubs['@oclif/core'].table.firstCall.args).to.deep.equal([TABLE_DATA, TABLE_COLUMNS]);
+    });
+
+    it('should stub ux.url', () => {
+      coreUx.url('oclif', 'oclif.io');
+      expect(uxStubs['@oclif/core'].url.firstCall.args).to.deep.equal(['oclif', 'oclif.io']);
+    });
+
+    it('should stub ux.styledHeader', () => {
+      coreUx.styledHeader('hello');
+      expect(uxStubs['@oclif/core'].styledHeader.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub ux.styledObject', () => {
+      coreUx.styledObject({ foo: 'bar' });
+      expect(uxStubs['@oclif/core'].styledObject.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub ux.styledJSON', () => {
+      coreUx.styledJSON({ foo: 'bar' });
+      expect(uxStubs['@oclif/core'].styledJSON.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub ux.action.start', () => {
+      coreUx.action.start('doing something');
+      expect(uxStubs['@oclif/core'].startSpinner.firstCall.args).to.deep.equal(['doing something']);
+    });
+
+    it('should stub ux.action.stop', () => {
+      coreUx.action.stop('done');
+      expect(uxStubs['@oclif/core'].stopSpinner.firstCall.args).to.deep.equal(['done']);
+    });
+  });
+
+  describe('SfCommand methods', () => {
+    it('should stub log', async () => {
+      await Cmd.run(['--log', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.log.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub logSuccess', async () => {
+      await Cmd.run(['--logSuccess', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.logSuccess.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub logSensitive', async () => {
+      await Cmd.run(['--logSensitive', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.logSensitive.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub logToStderr', async () => {
+      await Cmd.run(['--logToStderr', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.logToStderr.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub warn', async () => {
+      await Cmd.run(['--warn', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.warn.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub table', async () => {
+      await Cmd.run(['--table', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.table.firstCall.args).to.deep.equal([TABLE_DATA, TABLE_COLUMNS]);
+    });
+
+    it('should stub url', async () => {
+      await Cmd.run(['--url', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.url.firstCall.args).to.deep.equal(['oclif', 'https://oclif.io']);
+    });
+
+    it('should stub styledHeader', async () => {
+      await Cmd.run(['--styledHeader', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.styledHeader.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub styledObject', async () => {
+      await Cmd.run(['--styledObject', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.styledObject.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub styledJSON', async () => {
+      await Cmd.run(['--styledJSON', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.styledJSON.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub spinner', async () => {
+      await Cmd.run(['--spinner', '--method=SfCommand']);
+      expect(uxStubs.SfCommand.startSpinner.firstCall.args).to.deep.equal(['starting spinner']);
+      expect(uxStubs.SfCommand.stopSpinner.firstCall.args).to.deep.equal(['done']);
+    });
+  });
+
+  describe('@oclif/core ux utilities run in SfCommand', () => {
+    it('should stub log', async () => {
+      await Cmd.run(['--log', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].log.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub warn', async () => {
+      await Cmd.run(['--warn', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].warn.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub table', async () => {
+      await Cmd.run(['--table', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].table.firstCall.args).to.deep.equal([TABLE_DATA, TABLE_COLUMNS]);
+    });
+
+    it('should stub url', async () => {
+      await Cmd.run(['--url', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].url.firstCall.args).to.deep.equal(['oclif', 'https://oclif.io']);
+    });
+
+    it('should stub styledHeader', async () => {
+      await Cmd.run(['--styledHeader', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].styledHeader.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub styledObject', async () => {
+      await Cmd.run(['--styledObject', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].styledObject.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub styledJSON', async () => {
+      await Cmd.run(['--styledJSON', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].styledJSON.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub spinner', async () => {
+      await Cmd.run(['--spinner', '--method=@oclif/core']);
+      expect(uxStubs['@oclif/core'].startSpinner.firstCall.args).to.deep.equal(['starting spinner']);
+      expect(uxStubs['@oclif/core'].stopSpinner.firstCall.args).to.deep.equal(['done']);
+    });
+  });
+
+  describe('Ux methods run in SfCommand', () => {
+    it('should stub log', async () => {
+      await Cmd.run(['--log', '--method=Ux']);
+      expect(uxStubs.Ux.log.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub warn', async () => {
+      await Cmd.run(['--warn', '--method=Ux']);
+      expect(uxStubs.Ux.warn.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub table', async () => {
+      await Cmd.run(['--table', '--method=Ux']);
+      expect(uxStubs.Ux.table.firstCall.args).to.deep.equal([TABLE_DATA, TABLE_COLUMNS]);
+    });
+
+    it('should stub url', async () => {
+      await Cmd.run(['--url', '--method=Ux']);
+      expect(uxStubs.Ux.url.firstCall.args).to.deep.equal(['oclif', 'https://oclif.io']);
+    });
+
+    it('should stub styledHeader', async () => {
+      await Cmd.run(['--styledHeader', '--method=Ux']);
+      expect(uxStubs.Ux.styledHeader.firstCall.args).to.deep.equal(['hello']);
+    });
+
+    it('should stub styledObject', async () => {
+      await Cmd.run(['--styledObject', '--method=Ux']);
+      expect(uxStubs.Ux.styledObject.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub styledJSON', async () => {
+      await Cmd.run(['--styledJSON', '--method=Ux']);
+      expect(uxStubs.Ux.styledJSON.firstCall.args).to.deep.equal([{ foo: 'bar' }]);
+    });
+
+    it('should stub spinner', async () => {
+      await Cmd.run(['--spinner', '--method=Ux']);
+      expect(uxStubs.Ux.startSpinner.firstCall.args).to.deep.equal(['starting spinner']);
+      expect(uxStubs.Ux.stopSpinner.firstCall.args).to.deep.equal(['done']);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,40 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
+"@oclif/core@^2.1.1", "@oclif/core@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.1.4.tgz#536cf9d2367ba96c625076588b0cbccf3341829c"
+  integrity sha512-8rPS/gsjLgWp//nraRs5/yf7EkueFHBLRTMUli3yTu88XrQ2czbXIP2HsF2rxmtCqUUfXUTllHfr8OzqBs0Dcw==
+  dependencies:
+    "@types/cli-progress" "^3.11.0"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.11.2"
+    debug "^4.3.4"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.3.7"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.5.0"
+    widest-line "^3.1.0"
+    wordwrap "^1.0.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/dev-cli@^1":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.26.0.tgz#e3ec294b362c010ffc8948003d3770955c7951fd"
@@ -700,6 +734,15 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
+"@salesforce/kit@^1.8.3":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.5.tgz#3dcda46e7216363f8703c1c1d3b4dc5d80c1b4d3"
+  integrity sha512-py5M1PI5tWy/au/1tJ6qQBv7pHX3B4APqsNxg7yx/s2jbERUD6QNwcmWAayuRpZVVnFXBShBYROFZCojuNJwMA==
+  dependencies:
+    "@salesforce/ts-types" "^1.7.3"
+    shx "^0.3.3"
+    tslib "^2.5.0"
+
 "@salesforce/prettier-config@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"
@@ -709,6 +752,18 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.4.0.tgz#7dff427c8059895d8108176047aee600703c82d6"
   integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
+
+"@salesforce/sf-plugins-core@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-2.1.2.tgz#51a7a3d401ccfe18351f30eed60b59ce47df4ab4"
+  integrity sha512-XOLmtRDIQQbfewegxqWAOYRD0lypVyjl39XBrfu65qenfDfUXYcEDvDcWJFCnL+IwvUe4VhapFqmjZLMxG+YWA==
+  dependencies:
+    "@oclif/core" "^2.1.1"
+    "@salesforce/core" "^3.33.1"
+    "@salesforce/kit" "^1.8.3"
+    "@salesforce/ts-types" "^1.7.1"
+    chalk "^4"
+    inquirer "^8.2.5"
 
 "@salesforce/ts-sinon@^1.4.5":
   version "1.4.5"
@@ -725,6 +780,13 @@
   integrity sha512-eCpWKEb03UCKBJ6Svp0Vwcwt+fG6BQbopO4x5wt6CYeT8Rjt0dbDQicZPmVL59j2qyt3Q4Y4EYsxXUGZmdfvDw==
   dependencies:
     tslib "^2.4.1"
+
+"@salesforce/ts-types@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.3.tgz#89b79ff0aaa55fea9f2de0afa8e515be3e17d0d8"
+  integrity sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==
+  dependencies:
+    tslib "^2.5.0"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.3"
@@ -809,6 +871,13 @@
   version "4.2.18"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
   integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
+
+"@types/cli-progress@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.11.0.tgz#ec79df99b26757c3d1c7170af8422e0fc95eef7e"
+  integrity sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/debug@^4.1.5":
   version "4.1.7"
@@ -1109,7 +1178,7 @@ ansi-escapes@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -1133,7 +1202,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0, ansi-styles@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1297,6 +1366,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
@@ -1322,7 +1396,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bl@^4.0.3:
+bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -1494,6 +1568,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4, chalk@^4.0.2, chalk@^4.1.1, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
@@ -1555,7 +1637,7 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-clean-stack@^3.0.0:
+clean-stack@^3.0.0, clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
@@ -1569,6 +1651,13 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-progress@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.11.2.tgz#f8c89bd157e74f3f2c43bcfb3505670b4d48fc77"
+  integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
+  dependencies:
+    string-width "^4.2.3"
+
 cli-progress@^3.4.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.0.tgz#25db83447deb812e62d05bac1af9aec5387ef3d4"
@@ -1576,6 +1665,11 @@ cli-progress@^3.4.0:
   dependencies:
     colors "^1.1.2"
     string-width "^4.2.0"
+
+cli-spinners@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
 cli-ux@^5.2.1:
   version "5.5.1"
@@ -1631,6 +1725,11 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1945,6 +2044,13 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
+defaults@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
+  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
@@ -2027,6 +2133,13 @@ ecdsa-sig-formatter@1.0.11:
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
+
+ejs@^3.1.6:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
 
 electron-to-chromium@^1.3.723:
   version "1.3.752"
@@ -2588,6 +2701,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+filelist@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
+  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  dependencies:
+    minimatch "^5.0.1"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -2705,6 +2825,16 @@ fs-extra@^8.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3135,6 +3265,27 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.2.5:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 internal-slot@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.4.tgz#8551e7baf74a7a6ba5f749cfb16aa60722f0d6f3"
@@ -3225,6 +3376,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -3428,6 +3584,16 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
+
 js-sdsl@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
@@ -3445,7 +3611,7 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -3762,7 +3928,7 @@ lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.1.0:
+log-symbols@4.1.0, log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -3906,6 +4072,13 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
@@ -4042,7 +4215,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-natural-orderby@^2.0.1:
+natural-orderby@^2.0.1, natural-orderby@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
@@ -4188,7 +4361,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-treeify@^1.1.4:
+object-treeify@^1.1.33, object-treeify@^1.1.4:
   version "1.1.33"
   resolved "https://registry.yarnpkg.com/object-treeify/-/object-treeify-1.1.33.tgz#f06fece986830a3cba78ddd32d4c11d1f76cdf40"
   integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
@@ -4245,6 +4418,21 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -4722,6 +4910,13 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.5.5:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
+  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -5085,7 +5280,7 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-supports-color@8.1.1:
+supports-color@8.1.1, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -5110,6 +5305,14 @@ supports-hyperlinks@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
+supports-hyperlinks@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
+  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
@@ -5267,7 +5470,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.4.1, tslib@^2.5.0:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.4.1, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
@@ -5438,6 +5641,13 @@ vscode-textmate@^6.0.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-6.0.0.tgz#a3777197235036814ac9a92451492f2748589210"
   integrity sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==
 
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -5518,6 +5728,11 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 workerpool@6.2.0:
   version "6.2.0"


### PR DESCRIPTION
Adds `makeUxStubs` test util which will stub all the ux related methods in `SfCommand` (and the underlying `Ux`) and oclif/core's `ux`

All stubs are returned so that consumers can use those stubs in their test.

The `SfCommand` stubs are returned under the `SfCommand` key
The `Ux` stubs are returned under the `Ux` key
The `@oclif/core/ux` stubs are returned under the `@oclif/core` key

This alleviates the need for plugin providers to know which things they need to stub. However, returning the stubs under those keys does mean that plugin providers will need to understand which one to access when writing assertions.

@W-12429800@