### PR TITLE
fix: always return stdout and stderr from execCmd

### DIFF
--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -167,14 +167,13 @@ const execCmdSync = <T>(cmd: string, options?: ExecCmdOptions): ExecCmdResult<T>
   const startTime = process.hrtime();
   const code = (shelljs.exec(`${cmd} 1> ${stdoutFile} 2> ${stderrFile} `, cmdOptions) as ShellString).code;
 
-  if (code === 0) {
-    result.shellOutput = new ShellString(stripAnsi(fs.readFileSync(stdoutFileLocation, 'utf-8')));
-    result.shellOutput.stdout = stripAnsi(result.shellOutput.stdout);
-  } else {
-    result.shellOutput = new ShellString(stripAnsi(fs.readFileSync(stderrFileLocation, 'utf-8')));
-    // The ShellString constructor sets the argument as stdout, so we strip 'stdout' and set as stderr
-    result.shellOutput.stderr = stripAnsi(result.shellOutput.stdout);
-  }
+  // capture the output for both stdout and stderr
+  result.shellOutput = new ShellString(stripAnsi(fs.readFileSync(stdoutFileLocation, 'utf-8')));
+  result.shellOutput.stdout = stripAnsi(result.shellOutput.stdout);
+  const shellStringForStderr = new ShellString(stripAnsi(fs.readFileSync(stderrFileLocation, 'utf-8')));
+  // The ShellString constructor sets the argument as stdout, so we strip 'stdout' and set as stderr
+  result.shellOutput.stderr = stripAnsi(shellStringForStderr.stdout);
+
   result.shellOutput.code = code;
 
   result.execCmdDuration = hrtimeToMillisDuration(process.hrtime(startTime));

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -239,7 +239,7 @@ const execCmdAsync = async <T>(cmd: string, options: ExecCmdOptions): Promise<Ex
     };
     // Execute the command async in a child process
     const startTime = process.hrtime();
-    shelljs.exec(`${cmd} 1> ${stdoutFile} 2> ${stderrFile}`, cmdOptions, callback);
+    shelljs.exec(`${cmd} 1> ${stdoutFileLocation} 2> ${stderrFileLocation}`, cmdOptions, callback);
   });
 };
 

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -203,11 +203,9 @@ const execCmdAsync = async <T>(cmd: string, options: ExecCmdOptions): Promise<Ex
 
     debug(`Running cmd: ${cmd}`);
     debug(`Cmd options: ${inspect(cmdOptions)}`);
-    const stdoutFile = `${genUniqueString('stdout')}.txt`;
-    const stderrFile = `${genUniqueString('stderr')}.txt`;
     // buildCmdOptions will always
-    const stdoutFileLocation = pathJoin(cmdOptions.cwd ?? process.cwd(), stdoutFile);
-    const stderrFileLocation = pathJoin(cmdOptions.cwd ?? process.cwd(), stderrFile);
+    const stdoutFileLocation = pathJoin(cmdOptions.cwd, `${genUniqueString('stdout')}.txt`);
+    const stderrFileLocation = pathJoin(cmdOptions.cwd, `${genUniqueString('stderr')}.txt`);
     const callback: ExecCallback = (code, stdout, stderr) => {
       const execCmdDuration = hrtimeToMillisDuration(process.hrtime(startTime));
       debug(`Command completed with exit code: ${code}`);

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -6,7 +6,7 @@
  */
 import * as fs from 'fs';
 import { join } from 'path';
-import { expect, assert } from 'chai';
+import { expect, assert, config } from 'chai';
 import * as sinon from 'sinon';
 import { Duration, env } from '@salesforce/kit';
 import { stubMethod } from '@salesforce/ts-sinon';
@@ -14,6 +14,8 @@ import * as shelljs from 'shelljs';
 import { ShellString } from 'shelljs';
 import { beforeEach } from 'mocha';
 import { execCmd } from '../../src';
+
+config.truncateThreshold = 0;
 
 describe('execCmd (sync)', () => {
   const sandbox = sinon.createSandbox();
@@ -235,8 +237,8 @@ describe('execCmd (async)', () => {
     const execStub = stubMethod(sandbox, shelljs, 'exec').yields(0, shellString, '');
     await execCmd(cmd, { async: true });
     expect(execStub.args[0][0]).to.include(`${binPath} ${cmd}`);
-    expect(execStub.args[0][0]).to.include('1> stdout');
-    expect(execStub.args[0][0]).to.include('2> stderr');
+    expect(execStub.args[0][0]).to.match(/1> .*stdout.*txt/);
+    expect(execStub.args[0][0]).to.match(/2> .*stderr.*txt/);
   });
 
   it('should accept valid sfdx path in env var', async () => {
@@ -249,8 +251,8 @@ describe('execCmd (async)', () => {
     const execStub = stubMethod(sandbox, shelljs, 'exec').yields(0, shellString, '');
     await execCmd(cmd, { async: true });
     expect(execStub.args[0][0]).to.include(`${binPath} ${cmd}`);
-    expect(execStub.args[0][0]).to.include('1> stdout');
-    expect(execStub.args[0][0]).to.include('2> stderr');
+    expect(execStub.args[0][0]).to.match(/1> .*stdout.*txt/);
+    expect(execStub.args[0][0]).to.match(/2> .*stderr.*txt/);
   });
 
   it('should accept valid executable in the system path', async () => {
@@ -261,8 +263,8 @@ describe('execCmd (async)', () => {
     const execStub = stubMethod(sandbox, shelljs, 'exec').yields(0, shellString, '');
     await execCmd(cmd, { async: true });
     expect(execStub.args[0][0]).to.include(`${binPath} ${cmd}`);
-    expect(execStub.args[0][0]).to.include('1> stdout');
-    expect(execStub.args[0][0]).to.include('2> stderr');
+    expect(execStub.args[0][0]).to.match(/1> .*stdout.*txt/);
+    expect(execStub.args[0][0]).to.match(/2> .*stderr.*txt/);
   });
 
   it('should error when executable path not found', async () => {


### PR DESCRIPTION
@W-12556866@

Found an instance where a plugin command finishes successfully, but needed results were capture on both stdout and stderr.

Modified execCmd to return both stdout and stderr regardless of command exit code.