### PR TITLE
fix: remove deprecated sf env commands

### DIFF
--- a/src/hubAuth.ts
+++ b/src/hubAuth.ts
@@ -81,7 +81,7 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
     const jwtKey = prepareForJwt(homeDir);
 
     const results = shell.exec(
-      `sf org login jwt --set-default-dev-hub --username ${env.getString(
+      `sf org:login:jwt --set-default-dev-hub --username ${env.getString(
         'TESTKIT_HUB_USERNAME',
         ''
       )} --client-id ${env.getString(

--- a/src/hubAuth.ts
+++ b/src/hubAuth.ts
@@ -81,13 +81,13 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
     const jwtKey = prepareForJwt(homeDir);
 
     const results = shell.exec(
-      `sf login jwt org --set-default-dev-hub --username ${env.getString(
+      `sf org login jwt --set-default-dev-hub --username ${env.getString(
         'TESTKIT_HUB_USERNAME',
         ''
-      )} --clientid ${env.getString('TESTKIT_JWT_CLIENT_ID', '')} --keyfile ${jwtKey} --instance-url ${env.getString(
-        'TESTKIT_HUB_INSTANCE',
-        DEFAULT_INSTANCE_URL
-      )}`,
+      )} --client-id ${env.getString(
+        'TESTKIT_JWT_CLIENT_ID',
+        ''
+      )} --jwt-key-file ${jwtKey} --instance-url ${env.getString('TESTKIT_HUB_INSTANCE', DEFAULT_INSTANCE_URL)}`,
       execOpts
     ) as shell.ShellString;
 
@@ -107,11 +107,11 @@ export const testkitHubAuth = (homeDir: string, authStrategy: DevhubAuthStrategy
 
     const tmpUrl = prepareForAuthUrl(homeDir);
 
-    const shellOutput = shell.exec(`sfdx auth:sfdxurl:store -d -f ${tmpUrl}`, execOpts) as shell.ShellString;
+    const shellOutput = shell.exec(`sf org:login:sfdx-url -d -f ${tmpUrl}`, execOpts) as shell.ShellString;
     logger(shellOutput);
     if (shellOutput.code !== 0) {
       throw new Error(
-        `auth:sfdxurl for url ${tmpUrl} failed with exit code: ${shellOutput.code}\n ${
+        `org:login:sfdx-ur for url ${tmpUrl} failed with exit code: ${shellOutput.code}\n ${
           shellOutput.stdout + shellOutput.stderr
         }`
       );

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -192,7 +192,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
       const usernameOrAlias = configResults.result.find((org) => org.name === 'target-dev-hub')?.value;
       if (usernameOrAlias) {
         const displayEnv = shell.exec(
-          `sf env display -e ${usernameOrAlias} --json`,
+          `sf org display -o ${usernameOrAlias} --json`,
           this.shelljsExecOptions
         ) as shell.ShellString;
         const displayEnvResults = JSON.parse(stripAnsi(displayEnv.stdout)) as unknown as JsonOutput<OrgAuthorization>;
@@ -284,7 +284,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         if (this.orgsAliases.includes(org)) continue;
 
         this.debug(`Deleting test org: ${org}`);
-        const rv = shell.exec(`sf env delete scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
+        const rv = shell.exec(`sf org delete scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
         this.orgs.delete(org);
         if (rv.code !== 0) {
           // Must still delete the session dir if org:delete fails
@@ -349,7 +349,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
 
         if (org.username) {
           if (org.executable === 'sfdx') baseCmd += ` username=${org.username}`;
-          else throw new Error('username property is not supported by sf env create scratch');
+          else throw new Error('username property is not supported by sf org create scratch');
         }
 
         if (org.edition) {

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -192,7 +192,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
       const usernameOrAlias = configResults.result.find((org) => org.name === 'target-dev-hub')?.value;
       if (usernameOrAlias) {
         const displayEnv = shell.exec(
-          `sf org display -o ${usernameOrAlias} --json`,
+          `sf org:display -o ${usernameOrAlias} --json`,
           this.shelljsExecOptions
         ) as shell.ShellString;
         const displayEnvResults = JSON.parse(stripAnsi(displayEnv.stdout)) as unknown as JsonOutput<OrgAuthorization>;
@@ -284,7 +284,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         if (this.orgsAliases.includes(org)) continue;
 
         this.debug(`Deleting test org: ${org}`);
-        const rv = shell.exec(`sf org delete scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
+        const rv = shell.exec(`sf org:delete:scratch -o ${org} -p`, this.shelljsExecOptions) as shell.ShellString;
         this.orgs.delete(org);
         if (rv.code !== 0) {
           // Must still delete the session dir if org:delete fails

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -340,7 +340,7 @@ describe('TestSession', () => {
       await session.clean();
 
       expect(restoreSpy.called).to.equal(true);
-      expect(execStub.firstCall.args[0]).to.equal(`sf org delete scratch -o ${username} -p`);
+      expect(execStub.firstCall.args[0]).to.equal(`sf org:delete:scratch -o ${username} -p`);
       expect(rmStub.firstCall.args[0]).to.equal(session.dir);
       expect(rmStub.firstCall.args[1]).to.deep.equal(rmOptions);
     });

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -340,7 +340,7 @@ describe('TestSession', () => {
       await session.clean();
 
       expect(restoreSpy.called).to.equal(true);
-      expect(execStub.firstCall.args[0]).to.equal(`sf env delete scratch -o ${username} -p`);
+      expect(execStub.firstCall.args[0]).to.equal(`sf org delete scratch -o ${username} -p`);
       expect(rmStub.firstCall.args[0]).to.equal(session.dir);
       expect(rmStub.firstCall.args[1]).to.deep.equal(rmOptions);
     });


### PR DESCRIPTION
remove some busted references to sf env commands that are now in `org` topic