### PR TITLE
feat: shorter scratch org lifetime

### DIFF
--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -329,7 +329,10 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         }
 
         let baseCmd =
-          executable === 'sf' ? `${executable} env create scratch --json` : `${executable} force:org:create --json`;
+          executable === 'sf'
+            ? `${executable} env create scratch --json -y ${org.duration ?? '1'}`
+            : `${executable} force:org:create --json -d ${org.duration ?? '1'}`;
+        baseCmd += ` -w ${org.wait ?? 60}`;
 
         if (org.config) {
           baseCmd += ` -f ${org.config}`;
@@ -337,10 +340,6 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
 
         if (org.alias) {
           baseCmd += ` -a ${org.alias}`;
-        }
-
-        if (org.duration) {
-          baseCmd += executable === 'sf' ? ` -y ${org.duration}` : ` -d ${org.duration}`;
         }
 
         if (org.setDefault) {
@@ -354,12 +353,6 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
 
         if (org.edition) {
           baseCmd += executable === 'sf' ? ` -e ${org.edition}` : ` edition=${org.edition}`;
-        }
-
-        if (org.wait) {
-          baseCmd += ` -w ${org.wait}`;
-        } else {
-          baseCmd += ' -w 60';
         }
 
         const rv = shell.exec(baseCmd, this.shelljsExecOptions) as shell.ShellString;

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -180,7 +180,7 @@ describe('TestSession', () => {
       expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf env create scratch --json -f config/project-scratch-def.json -w 60'
+        'sf env create scratch --json -y 1 -w 60 -f config/project-scratch-def.json'
       );
     });
 
@@ -215,7 +215,7 @@ describe('TestSession', () => {
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(session.orgs.get('default')).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf env create scratch --json -f config/project-scratch-def.json -a my-org -y 1 -d -e developer -w 60'
+        'sf env create scratch --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer'
       );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
@@ -256,7 +256,7 @@ describe('TestSession', () => {
 
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const expectedCmd = 'sf env create scratch --json -f config/project-scratch-def.json -w 60';
+      const expectedCmd = 'sf env create scratch --json -y 1 -w 60 -f config/project-scratch-def.json';
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;


### PR DESCRIPTION
scratch orgs that fail to delete (for whatever reason including commands being canceled) don't need to sit around for a week.

[skip-validate-pr]