### PR TITLE
test: ut don't assert kit's responsibilities

### DIFF
--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -192,7 +192,6 @@ describe('execCmd (sync)', () => {
     expect(result.jsonOutput).to.deep.equal(undefined);
     expect(result.jsonError).to.be.an('Error');
     expect(result.jsonError?.name).to.equal('JsonParseError');
-    expect(result.jsonError?.message).to.match(/Parse error in file unknown on line 1\n\r?try JSON parsing this/);
   });
 
   it('should override shell default', () => {
@@ -334,7 +333,6 @@ describe('execCmd (async)', () => {
     expect(result.jsonOutput).to.deep.equal(undefined);
     expect(result.jsonError).to.be.an('Error');
     expect(result.jsonError?.name).to.equal('JsonParseError');
-    expect(result.jsonError?.message).to.match(/Parse error in file unknown on line 1\n\r?try JSON parsing this/);
   });
 
   it('should override shell default', async () => {


### PR DESCRIPTION
JSON.parse got smarter on newer node versions.  That caused some of our assertions to fail.

I've removed the assertions that testkit shouldn't have an opinion about (assert the error type and let native JSON.parse and kit handle the message contents).  This *should* work across all node versions.

bigger picture, maybe we don't need jsonParse function and all of its fancy error constructors one 20 is the minimum.

18.15
```
> JSON.parse('{')
Uncaught SyntaxError: Unexpected end of JSON input
```
20
```
> JSON.parse('{')
Uncaught SyntaxError: Expected property name or '}' in JSON at position 1
```

https://github.com/salesforcecli/cli-plugins-testkit/actions/runs/5363099922/jobs/9730439483?pr=498