### PR TITLE
fix: ignore errors from when sessionDir can't be deleted

### DIFF
--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -75,7 +75,7 @@ export interface TestSessionOptions {
 }
 
 // exported for test assertions
-export const rmOptions = { recursive: true, force: true, maxRetries: 5, retryDelay: 2000 };
+export const rmOptions = { recursive: true, force: true };
 /**
  * Represents a test session, which is a unique location for non-unit test (nut)
  * artifacts such as a project and a mocked home dir.  It also provides easy


### PR DESCRIPTION
sometimes testkit session.clean fails (because file activity is still happening).  Some of the nuts have try/catch around that, which we can now remove.

There's a nodejs bug about lstat quirks on windows.  https://github.com/nodejs/node/issues/45253

I've been running this on windows to try to solve 
https://github.com/forcedotcom/sfdx-core/actions/runs/5477437565/jobs/9976954011#step:13:202

I've got it isolated, and using the debugger/debug console, it'll hang on `fs.rm` when the retry options are present, even if the timeout/max are set to a really low limit.  An EPERM just causes it to get stuck.

It's possible that on windows, logger is leaving the log file open until the worker_thread finisihes, which causes lstat problems (EPERM) during the rm retries.  We'll test that potential issue separately.

the goal of this PR is to decouple testkit's cleanup issues from "did my NUT pass/fail" to reduce flap.