### PR TITLE
feat: project api version

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -14,6 +14,7 @@ WARNING: THIS IS A GENERATED FILE. DO NOT MODIFY DIRECTLY.  USE topics.json
 ### TestSession Class
 
 - [Testing with generated sfdx project](#testing-with-generated-sfdx-project)
+- [Testing with generated sfdx project with a specific api version](#testing-with-generated-sfdx-project-with-a-specific-api-version)
 - [Testing with local sfdx project](#testing-with-local-sfdx-project)
 - [Testing with git cloned sfdx project](#testing-with-git-cloned-sfdx-project)
 - [Testing with no sfdx project](#testing-with-no-sfdx-project)
@@ -187,6 +188,41 @@ describe('TestSession', () => {
     testSession = await TestSession.create({
       project: {
         name: 'MyTestProject',
+      },
+    });
+  });
+
+  it('should run a command from within a generated project', () => {
+    execCmd('project:convert:source', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});
+```
+
+## Testing with generated sfdx project with a specific api version
+
+**_Usecase: I have a plugin with commands that require a SFDX project that need a specific api version in the sfdx-project.json._**
+
+```typescript
+import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+describe('TestSession', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+        apiVersion: '57.0',
       },
     });
   });

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -102,12 +102,7 @@ describe('execCmd', () => {
 
 ```typescript
 import { execCmd } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('execCmd', () => {
   // This would actually be set in the shell or CI environment.
@@ -174,12 +169,7 @@ A TestSession provides conveniences to testing plugin commands with options to a
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -208,12 +198,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -300,12 +285,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -330,12 +310,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 import { tmpdir } from 'os';
 import { expect } from 'chai';
 
@@ -417,12 +392,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -453,12 +423,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -491,12 +456,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -527,12 +487,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 import * as path from 'path';
 
 describe('TestSession', () => {
@@ -573,12 +528,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+TestProjectBaseOptions;
 import * as shelljs from 'shelljs';
 
 /*

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -102,7 +102,6 @@ describe('execCmd', () => {
 
 ```typescript
 import { execCmd } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('execCmd', () => {
   // This would actually be set in the shell or CI environment.
@@ -169,7 +168,6 @@ A TestSession provides conveniences to testing plugin commands with options to a
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -198,7 +196,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -285,7 +282,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -310,7 +306,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
+
 import { tmpdir } from 'os';
 import { expect } from 'chai';
 
@@ -392,7 +388,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -423,7 +418,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -456,7 +450,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -487,7 +480,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
+
 import * as path from 'path';
 
 describe('TestSession', () => {
@@ -528,7 +521,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-TestProjectBaseOptions;
+
 import * as shelljs from 'shelljs';
 
 /*

--- a/samples/TestSession.sample1b.nut.ts
+++ b/samples/TestSession.sample1b.nut.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd } from '../src/execCmd';
+import { TestSession } from '../src/testSession';
+
+describe('TestSession', () => {
+  let testSession: TestSession;
+
+  before(async () => {
+    testSession = await TestSession.create({
+      project: {
+        name: 'MyTestProject',
+        apiVersion: '57.0',
+      },
+    });
+  });
+
+  it('should run a command from within a generated project', () => {
+    execCmd('project:convert:source', { ensureExitCode: 0 });
+  });
+
+  after(async () => {
+    await testSession?.clean();
+  });
+});

--- a/samples/topics.json
+++ b/samples/topics.json
@@ -49,6 +49,11 @@
         "file": "TestSession.sample1.nut.ts"
       },
       {
+        "header": "Testing with generated sfdx project with a specific api version",
+        "usecase": "I have a plugin with commands that require a SFDX project that need a specific api version in the sfdx-project.json.",
+        "file": "TestSession.sample1b.nut.ts"
+      },
+      {
         "header": "Testing with local sfdx project",
         "usecase": "I have a plugin with commands that require a SFDX project and the test project I want to use is in a local directory within my plugin repo.",
         "file": "TestSession.sample2.nut.ts"

--- a/src/testProject.ts
+++ b/src/testProject.ts
@@ -17,7 +17,11 @@ import { zipDir, ZipDirConfig } from './zip';
 export type TestProjectOptions = {
   name?: string;
   destinationDir?: string;
-} & ({ sourceDir: string } | { gitClone: string } | { apiVersion?: `${number}.0` });
+} & (
+  | { sourceDir: string; gitClone?: never; apiVersion?: never }
+  | { gitClone: string; sourceDir?: never; apiVersion?: never }
+  | { apiVersion?: `${number}.0`; sourceDir?: never; gitClone?: never }
+);
 
 /**
  * A SFDX project for use with testing.  The project can be defined by:
@@ -51,7 +55,7 @@ export class TestProject {
     }
 
     // Copy a dir containing a SFDX project to a dir for testing.
-    if ('sourceDir' in options) {
+    if (options.sourceDir) {
       const rv = shell.cp('-r', options.sourceDir, destDir);
       if (rv.code !== 0) {
         throw new Error(`project copy failed with error:\n${rv.stderr}`);
@@ -59,7 +63,7 @@ export class TestProject {
       this.dir = path.join(destDir, path.basename(options.sourceDir));
     }
     // Clone a git repo containing a SFDX project in a dir for testing.
-    else if ('gitClone' in options) {
+    else if (options.gitClone) {
       // verify git is found
       if (!shell.which('git')) {
         throw new Error('git executable not found for creating a project from a git clone');

--- a/src/testProject.ts
+++ b/src/testProject.ts
@@ -14,12 +14,10 @@ import { env } from '@salesforce/kit';
 import { genUniqueString } from './genUniqueString';
 import { zipDir, ZipDirConfig } from './zip';
 
-type apiVersionNumber = number;
-
 export type TestProjectOptions = {
   name?: string;
   destinationDir?: string;
-} & ({ sourceDir: string } | { gitClone: string } | { apiVersion?: `${apiVersionNumber}.0` });
+} & ({ sourceDir: string } | { gitClone: string } | { apiVersion?: `${number}.0` });
 
 /**
  * A SFDX project for use with testing.  The project can be defined by:

--- a/src/testProject.ts
+++ b/src/testProject.ts
@@ -14,10 +14,12 @@ import { env } from '@salesforce/kit';
 import { genUniqueString } from './genUniqueString';
 import { zipDir, ZipDirConfig } from './zip';
 
+type apiVersionNumber = number;
+
 export type TestProjectOptions = {
   name?: string;
   destinationDir?: string;
-} & ({ sourceDir: string } | { gitClone: string } | { apiVersion?: string });
+} & ({ sourceDir: string } | { gitClone: string } | { apiVersion?: `${apiVersionNumber}.0` });
 
 /**
  * A SFDX project for use with testing.  The project can be defined by:

--- a/src/testProject.ts
+++ b/src/testProject.ts
@@ -18,9 +18,9 @@ export type TestProjectOptions = {
   name?: string;
   destinationDir?: string;
 } & (
-  | { sourceDir: string; gitClone?: never; apiVersion?: never }
-  | { gitClone: string; sourceDir?: never; apiVersion?: never }
-  | { apiVersion?: `${number}.0`; sourceDir?: never; gitClone?: never }
+  | { sourceDir?: string; gitClone?: never; apiVersion?: never }
+  | { sourceDir?: never; gitClone?: string; apiVersion?: never }
+  | { sourceDir?: never; gitClone?: never; apiVersion?: string }
 );
 
 /**

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -340,7 +340,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
           throw new Error(`${executable} executable not found for creating scratch orgs`);
         }
 
-        let baseCmd = `sf env:create:scratch --json -y ${org.duration ?? '1'} -w ${org.wait ?? 60}`;
+        let baseCmd = `sf org:create:scratch --json -y ${org.duration ?? '1'} -w ${org.wait ?? 60}`;
 
         if (org.config) {
           baseCmd += ` -f ${org.config}`;
@@ -355,7 +355,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         }
 
         if (org.username) {
-          baseCmd += `--username ${org.username}`;
+          baseCmd += ` --username ${org.username}`;
         }
 
         if (org.edition) {

--- a/test/unit/testProject.test.ts
+++ b/test/unit/testProject.test.ts
@@ -107,6 +107,23 @@ describe('TestProject', () => {
     expect(execStub.firstCall.args[1]).to.have.property('shell', shellOverride);
   });
 
+  it('should generate from a name with api version', () => {
+    const apiVersion = '50.0';
+    stubMethod(sandbox, shelljs, 'which').returns(true);
+    const shellOverride = 'powershell.exe';
+    stubMethod(sandbox, env, 'getString').returns(shellOverride);
+    const shellString = new ShellString('');
+    shellString.code = 0;
+    const execStub = stubMethod(sandbox, shelljs, 'exec').returns(shellString);
+    const name = 'MyTestProject';
+    const destinationDir = pathJoin('foo', 'bar');
+    const testProject = new TestProject({ name, destinationDir, apiVersion });
+    expect(testProject.dir).to.equal(pathJoin(destinationDir, name));
+    const execArg1 = `sf project:generate -n ${name} -d ${destinationDir} --api-version ${apiVersion}`;
+    expect(execStub.firstCall.args[0]).to.equal(execArg1);
+    expect(execStub.firstCall.args[1]).to.have.property('shell', shellOverride);
+  });
+
   it('should generate by default', () => {
     stubMethod(sandbox, shelljs, 'which').returns(true);
     const shellString = new ShellString('');

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -180,7 +180,7 @@ describe('TestSession', () => {
       expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf env:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json'
+        'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json'
       );
     });
 
@@ -215,7 +215,7 @@ describe('TestSession', () => {
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(session.orgs.get('default')).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf env:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer'
+        'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer'
       );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
@@ -256,7 +256,7 @@ describe('TestSession', () => {
 
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const expectedCmd = 'sf env:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json';
+      const expectedCmd = 'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json';
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;


### PR DESCRIPTION
let a NUT specify the api version of their project
make the type for TestProjectOptions richer to prevent invalid combinations (previously, sourceDir and gitClone could be specified and you'd get sourceDir because that's the first thing the code checked)

[@W-13913391@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001XvsAqYAJ/view)