### PR TITLE
fix: update bin/dev|run exec for when run.js exist

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -102,12 +102,6 @@ describe('execCmd', () => {
 
 ```typescript
 import { execCmd } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('execCmd', () => {
   // This would actually be set in the shell or CI environment.
@@ -174,12 +168,6 @@ A TestSession provides conveniences to testing plugin commands with options to a
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -208,12 +196,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -300,12 +282,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -330,12 +306,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+
 import { tmpdir } from 'os';
 import { expect } from 'chai';
 
@@ -417,12 +388,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -453,12 +418,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -491,12 +450,6 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -527,12 +480,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+
 import * as path from 'path';
 
 describe('TestSession', () => {
@@ -573,12 +521,7 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-/*
- * Copyright (c) 2023, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- */
+
 import * as shelljs from 'shelljs';
 
 /*

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -102,6 +102,12 @@ describe('execCmd', () => {
 
 ```typescript
 import { execCmd } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('execCmd', () => {
   // This would actually be set in the shell or CI environment.
@@ -168,6 +174,12 @@ A TestSession provides conveniences to testing plugin commands with options to a
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -196,6 +208,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -282,6 +300,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -306,7 +330,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 import { tmpdir } from 'os';
 import { expect } from 'chai';
 
@@ -388,6 +417,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -418,6 +453,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -450,6 +491,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 
 describe('TestSession', () => {
   let testSession: TestSession;
@@ -480,7 +527,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession, TestProject } from '@salesforce/cli-plugins-testkit';
-
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 import * as path from 'path';
 
 describe('TestSession', () => {
@@ -521,7 +573,12 @@ describe('TestSession', () => {
 
 ```typescript
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 import * as shelljs from 'shelljs';
 
 /*

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -161,11 +161,17 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
       // TESTKIT_EXECUTABLE_PATH env var is not being used, then set it
       // to use the bin/dev from the cwd now.
       if (!env.getString('TESTKIT_EXECUTABLE_PATH')) {
-        const binDev = path.join(process.cwd(), 'bin', 'dev');
-        env.setString(
-          'TESTKIT_EXECUTABLE_PATH',
-          fs.existsSync(binDev) ? binDev : path.join(process.cwd(), 'bin', 'run')
-        );
+        let binDev = path.join(process.cwd(), 'bin', 'dev');
+        if (!fs.existsSync(binDev)) {
+          binDev += '.js';
+        }
+
+        // only used in the case when bin/run or bin/run.js doesn't exist
+        let binRun = path.join(process.cwd(), 'bin', 'run');
+        if (!fs.existsSync(binRun)) {
+          binRun += '.js';
+        }
+        env.setString('TESTKIT_EXECUTABLE_PATH', fs.existsSync(binDev) ? binDev : binRun);
       }
 
       this.stubCwd(projectDir);

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -166,7 +166,7 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
           binDev += '.js';
         }
 
-        // only used in the case when bin/run or bin/run.js doesn't exist
+        // only used in the case when bin/dev or bin/dev.js doesn't exist
         let binRun = path.join(process.cwd(), 'bin', 'run');
         if (!fs.existsSync(binRun)) {
           binRun += '.js';


### PR DESCRIPTION
[skip-validate-pr]

allows NUTs to run ESM executables 