### PR TITLE
feat!: use bin/run.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "4.4.12-dev.0",
+  "version": "5.0.0-dev.0",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "5.0.0-dev.1",
+  "version": "5.0.0-dev.2",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "4.4.11",
+  "version": "4.4.12-dev.0",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "5.0.0-dev.0",
+  "version": "5.0.0-dev.1",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -17,7 +17,7 @@ import { ExecCallback, ExecOptions, ShellString } from 'shelljs';
 import stripAnsi = require('strip-ansi');
 import { genUniqueString } from './genUniqueString';
 
-export type CLI = 'inherit' | 'sfdx' | 'sf';
+export type CLI = 'inherit' | 'sfdx' | 'sf' | 'dev';
 
 type BaseExecOptions = {
   /**
@@ -118,17 +118,31 @@ const getExitCodeError = (cmd: string, expectedCode: number, output: ShellString
  *
  * @returns The command string with CLI executable. E.g., `"node_modules/bin/sf org:create:user -a testuser1"`
  */
-const determineExecutable = (cli: CLI = 'inherit'): string => {
+export const determineExecutable = (cli: CLI = 'inherit'): string => {
   const debug = Debug('testkit:determineExecutable');
 
-  let bin =
-    cli === 'inherit'
-      ? env.getString('TESTKIT_EXECUTABLE_PATH') ??
-        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js')
-      : cli;
+  let bin: string | undefined;
+  switch (cli) {
+    case 'inherit':
+      bin =
+        env.getString('TESTKIT_EXECUTABLE_PATH') ??
+        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js');
+      break;
+    case 'dev':
+      bin =
+        env.getString('TESTKIT_EXECUTABLE_PATH') ??
+        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev.js');
+      break;
+    case 'sfdx':
+      bin = cli;
+      break;
+    case 'sf':
+      bin = cli;
+      break;
+  }
 
   // Support plugins who still use bin/run instead of bin/run.js
-  if (bin.endsWith('run.js') && !fs.existsSync(bin)) bin = bin.replace('.js', '');
+  if (bin.endsWith('.js') && !fs.existsSync(bin)) bin = bin.replace('.js', '');
   const which = shelljs.which(bin);
   let resolvedPath = pathResolve(bin);
 

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -114,7 +114,7 @@ const getExitCodeError = (cmd: string, expectedCode: number, output: ShellString
  *
  * If the cli is 'inherit', the executable preference order is:
  *    1. TESTKIT_EXECUTABLE_PATH env var
- *    2. `bin/dev.js` (default)
+ *    2. `bin/run.js` (default)
  *
  * @returns The command string with CLI executable. E.g., `"node_modules/bin/sf org:create:user -a testuser1"`
  */
@@ -124,11 +124,11 @@ const determineExecutable = (cli: CLI = 'inherit'): string => {
   let bin =
     cli === 'inherit'
       ? env.getString('TESTKIT_EXECUTABLE_PATH') ??
-        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev.js')
+        pathJoin(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js')
       : cli;
 
-  // Support plugins who still use bin/dev instead of bin/dev.js
-  if (bin.endsWith('dev.js') && !fs.existsSync(bin)) bin = bin.replace('.js', '');
+  // Support plugins who still use bin/run instead of bin/run.js
+  if (bin.endsWith('run.js') && !fs.existsSync(bin)) bin = bin.replace('.js', '');
   const which = shelljs.which(bin);
   let resolvedPath = pathResolve(bin);
 

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -19,7 +19,7 @@ import { zipDir } from './zip';
 
 import { TestProject, TestProjectOptions } from './testProject';
 import { DevhubAuthStrategy, getAuthStrategy, testkitHubAuth, transferExistingAuthToEnv } from './hubAuth';
-import { JsonOutput } from './execCmd';
+import { determineExecutable, JsonOutput } from './execCmd';
 
 export type ScratchOrgConfig = {
   /**
@@ -156,16 +156,12 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         projectDir = this.project.dir;
       }
 
-      // The default bin/run in execCmd will no longer resolve properly when
+      // The default bin/run.js in execCmd will no longer resolve properly when
       // a test project is used since process.cwd is changed.  If the
       // TESTKIT_EXECUTABLE_PATH env var is not being used, then set it
-      // to use the bin/dev from the cwd now.
+      // to use the bin/run.js from the cwd now.
       if (!env.getString('TESTKIT_EXECUTABLE_PATH')) {
-        let binRun = path.join(process.cwd(), 'bin', 'run');
-        if (!fs.existsSync(binRun)) {
-          binRun += '.js';
-        }
-        env.setString('TESTKIT_EXECUTABLE_PATH', binRun);
+        env.setString('TESTKIT_EXECUTABLE_PATH', determineExecutable('inherit'));
       }
 
       this.stubCwd(projectDir);

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -156,22 +156,16 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
         projectDir = this.project.dir;
       }
 
-      // The default bin/dev in execCmd will no longer resolve properly when
+      // The default bin/run in execCmd will no longer resolve properly when
       // a test project is used since process.cwd is changed.  If the
       // TESTKIT_EXECUTABLE_PATH env var is not being used, then set it
       // to use the bin/dev from the cwd now.
       if (!env.getString('TESTKIT_EXECUTABLE_PATH')) {
-        let binDev = path.join(process.cwd(), 'bin', 'dev');
-        if (!fs.existsSync(binDev)) {
-          binDev += '.js';
-        }
-
-        // only used in the case when bin/dev or bin/dev.js doesn't exist
         let binRun = path.join(process.cwd(), 'bin', 'run');
         if (!fs.existsSync(binRun)) {
           binRun += '.js';
         }
-        env.setString('TESTKIT_EXECUTABLE_PATH', fs.existsSync(binDev) ? binDev : binRun);
+        env.setString('TESTKIT_EXECUTABLE_PATH', binRun);
       }
 
       this.stubCwd(projectDir);

--- a/test/unit/execCmd.test.ts
+++ b/test/unit/execCmd.test.ts
@@ -37,8 +37,8 @@ describe('execCmd (sync)', () => {
     sandbox.restore();
   });
 
-  it('should default to bin/dev.js executable', () => {
-    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev.js');
+  it('should default to bin/run.js executable', () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js');
     sandbox.stub(fs, 'existsSync').returns(true);
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
     const shellString = new ShellString(JSON.stringify(output));
@@ -49,8 +49,8 @@ describe('execCmd (sync)', () => {
     expect(execStub.args[0][0]).to.include('2> stderr');
   });
 
-  it('should default to bin/dev executable if bin/dev.js does not exist', async () => {
-    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev');
+  it('should default to bin/run executable if bin/run.js does not exist', async () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run');
     sandbox.stub(fs, 'existsSync').withArgs(binPath).returns(false).withArgs(binPath.replace('.js', '')).returns(true);
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
     const shellString = new ShellString(JSON.stringify(output));
@@ -61,8 +61,8 @@ describe('execCmd (sync)', () => {
     expect(execStub.args[0][0]).to.include('2> stderr');
   });
 
-  it('should default to bin/dev.js executable when cli = inherit', () => {
-    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev.js');
+  it('should default to bin/run.js executable when cli = inherit', () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js');
     sandbox.stub(fs, 'existsSync').returns(true);
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
     const shellString = new ShellString(JSON.stringify(output));
@@ -121,7 +121,7 @@ describe('execCmd (sync)', () => {
   });
 
   it('should error when executable path not found', () => {
-    const binPath = join(process.cwd(), 'bin', 'dev');
+    const binPath = join(process.cwd(), 'bin', 'run');
     try {
       execCmd(cmd);
       assert(false, 'Expected an error to be thrown');
@@ -240,8 +240,8 @@ describe('execCmd (async)', () => {
     sandbox.restore();
   });
 
-  it('should default to bin/dev.js executable', async () => {
-    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev.js');
+  it('should default to bin/run.js executable', async () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run.js');
     sandbox.stub(fs, 'existsSync').returns(true);
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
     const shellString = new ShellString(JSON.stringify(output));
@@ -252,8 +252,8 @@ describe('execCmd (async)', () => {
     expect(execStub.args[0][0]).to.match(/2> .*stderr.*txt/);
   });
 
-  it('should default to bin/dev executable if bin/dev.js does not exist', async () => {
-    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'dev.cmd' : 'dev');
+  it('should default to bin/run executable if bin/run.js does not exist', async () => {
+    const binPath = join(process.cwd(), 'bin', process.platform === 'win32' ? 'run.cmd' : 'run');
     sandbox.stub(fs, 'existsSync').withArgs(binPath).returns(false).withArgs(binPath.replace('.js', '')).returns(true);
     sandbox.stub(shelljs, 'which').callsFake((x) => new ShellString(x));
     const shellString = new ShellString(JSON.stringify(output));
@@ -291,7 +291,7 @@ describe('execCmd (async)', () => {
   });
 
   it('should error when executable path not found', async () => {
-    const binPath = join(process.cwd(), 'bin', 'dev');
+    const binPath = join(process.cwd(), 'bin', 'run');
     try {
       await execCmd(cmd, { async: true });
       assert(false, 'Expected an error to be thrown');

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -99,6 +99,8 @@ describe('TestSession', () => {
       const shellString = new ShellString('');
       shellString.code = 0;
       stubMethod(sandbox, shelljs, 'cp').returns(shellString);
+      stubMethod(sandbox, shelljs, 'which').returns(shellString);
+      stubMethod(sandbox, fs, 'existsSync').returns(true);
       const stubCwdStub = stubMethod(sandbox, TestSession.prototype, 'stubCwd');
 
       const session = await TestSession.create({ project: { sourceDir } });
@@ -130,6 +132,8 @@ describe('TestSession', () => {
       const shellString = new ShellString('');
       shellString.code = 0;
       stubMethod(sandbox, shelljs, 'cp').returns(shellString);
+      stubMethod(sandbox, shelljs, 'which').returns(shellString);
+      stubMethod(sandbox, fs, 'existsSync').returns(true);
       const stubCwdStub = stubMethod(sandbox, TestSession.prototype, 'stubCwd');
 
       const session = await TestSession.create({ project: { sourceDir } });


### PR DESCRIPTION
Use `bin/run.js` for executing local commands. This is a breaking change since any NUTs depending on `devPlugins` will no longer be able to use them.

[Successful test run](https://github.com/salesforcecli/plugin-limits/actions/runs/6696659435/job/18194935543)

@W-14390800@