### PR TITLE
fix: regex for new inquirer select

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 ## Contributing
 
 1. The [DEVELOPING](DEVELOPING.md) doc has details on how to set up your environment.
-1. Familiarize yourself with the codebase by reading the [docs](docs), which you can generate locally by running `yarn docs`.
 1. Create a new issue before starting your project so that we can keep track of
    what you are trying to add/fix. That way, we can also offer suggestions or
    let you know if there is already an effort in progress.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,10 +34,6 @@ This cleans all generated files and directories. Run `yarn clean-all` to also cl
 
 This tests the typescript using ts-node.
 
-### `yarn docs`
-
-This generates documentation into [docs](docs).
-
 ### `yarn lint`
 
 This lints all the typescript. If there are no errors/warnings

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023, Salesforce.com, Inc.
+Copyright (c) 2024, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![NPM](https://img.shields.io/npm/v/@salesforce/cli-plugins-testkit.svg)](https://www.npmjs.com/package/@salesforce/cli-plugins-testkit)
-[![CircleCI](https://circleci.com/gh/salesforcecli/cli-plugins-testkit.svg?style=svg&circle-token=2377ca31221869e9d13448313620486da80e595f)](https://circleci.com/gh/salesforcecli/cli-plugins-testkit)
 
 # Description
 

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -413,7 +413,10 @@ export async function execInteractiveCmd(
       const shouldScrollForAnswer = current.includes('❯') && scrollTarget;
 
       if (shouldScrollForAnswer) {
-        const regex = /(?<=❯\s)(.*)/g;
+        // recent inquirer versions include a unicode character in the prompt that we need to strip out
+        // it's something like a backspace or a backline character used to type over existing output
+        // this generally removes all the "control" characters in the first section of unicode
+        const regex = /(?<=❯\s)([\u0020-\u00d7ff]+)/g;
         const selected = (current.match(regex) ?? [''])[0].trim();
         if (selected === scrollTarget) {
           seen.add(matchingQuestion);


### PR DESCRIPTION
there's unicode characters in the updated inquirer lists that were keeping the NUT automation from finding the expected values 

side-quest during @W-14795554@, which requires this change

an example from debug (note where the `"` ends up on the 2nd line 
```
testkit:execInteractiveCmd should scroll for answer: "hello world" +0ms
testkit:exe" +0msactiveCmd selected: "hello world
```