### PR TITLE
feat: execInteractive takes string or string[]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "5.2.4-qa.0",
+  "version": "5.2.4-qa.1",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/cli-plugins-testkit",
   "description": "Provides test utilities to assist Salesforce CLI plug-in authors with writing non-unit tests (NUT).",
-  "version": "5.2.3",
+  "version": "5.2.4-qa.0",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/src/execCmd.ts
+++ b/src/execCmd.ts
@@ -378,6 +378,11 @@ export async function execInteractiveCmd(
   const debug = Debug('testkit:execInteractiveCmd');
 
   return new Promise((resolve, reject) => {
+    if (typeof command === 'string' && command.includes('"')) {
+      throw new Error(
+        'Use an array of strings to represent the command when it includes quotes, ex: ["some:cmd", "--flag", "value with spaces"]'
+      );
+    }
     const bin = determineExecutable(options?.cli).trim();
     const startTime = process.hrtime();
     const opts =


### PR DESCRIPTION
execInteractiveCmd has a problem with spaces (it does split on ' ') but that also hits the spaces inside double quotes in flag values like `--flag "space here"`

This provides the alternative to pass in the normal "argv" structure like execInteractiveCmd(['mycmd', '--flag', '"space here"']) 

also cleaned up some param-reassign linter stuff in execCmd module

used here (proof of correctness) https://github.com/salesforcecli/plugin-deploy-retrieve/pull/988


