### PR TITLE
fix: add scratch org description

### DIFF
--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -72,7 +72,7 @@ export type TestSessionOptions = {
    * The number of times to retry the scratch org create after the initial attempt if it fails. Will be overridden by TESTKIT_SETUP_RETRIES environment variable.
    */
   retries?: number;
-}
+};
 
 // exported for test assertions
 export const rmOptions = { recursive: true, force: true };
@@ -334,7 +334,9 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
           throw new Error(`${executable} executable not found for creating scratch orgs`);
         }
 
-        let baseCmd = `sf org:create:scratch --json -y ${org.duration ?? '1'} -w ${org.wait ?? 60}`;
+        let baseCmd = `sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y ${
+          org.duration ?? '1'
+        } -w ${org.wait ?? 60}`;
 
         if (org.config) {
           baseCmd += ` -f ${org.config}`;

--- a/src/testSession.ts
+++ b/src/testSession.ts
@@ -334,9 +334,9 @@ export class TestSession<T extends TestSessionOptions = TestSessionOptions> exte
           throw new Error(`${executable} executable not found for creating scratch orgs`);
         }
 
-        let baseCmd = `sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y ${
-          org.duration ?? '1'
-        } -w ${org.wait ?? 60}`;
+        let baseCmd = `sf org:create:scratch --name 'cli-plugins-testkit' --json -y ${org.duration ?? '1'} -w ${
+          org.wait ?? 60
+        }`;
 
         if (org.config) {
           baseCmd += ` -f ${org.config}`;

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -184,7 +184,7 @@ describe('TestSession', () => {
       expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json'
+        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json"
       );
     });
 
@@ -218,7 +218,7 @@ describe('TestSession', () => {
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(session.orgs.get('default')).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer'
+        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer"
       );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
@@ -259,7 +259,8 @@ describe('TestSession', () => {
 
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
-      const expectedCmd = 'sf org:create:scratch --json -y 1 -w 60 -f config/project-scratch-def.json';
+      const expectedCmd =
+        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json";
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;

--- a/test/unit/testSession.test.ts
+++ b/test/unit/testSession.test.ts
@@ -184,7 +184,7 @@ describe('TestSession', () => {
       expect(execStub.callCount).to.equal(scratchOrgs.length * (retries + 1));
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json"
+        "sf org:create:scratch --name 'cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json"
       );
     });
 
@@ -218,7 +218,7 @@ describe('TestSession', () => {
       expect(session.orgs.get(username)).to.deep.equal({ username, orgId: '12345' });
       expect(session.orgs.get('default')).to.deep.equal({ username, orgId: '12345' });
       expect(execStub.firstCall.args[0]).to.equal(
-        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer"
+        "sf org:create:scratch --name 'cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json -a my-org -d -e developer"
       );
       expect(process.env.HOME).to.equal(session.homeDir);
       expect(process.env.USERPROFILE).to.equal(session.homeDir);
@@ -260,7 +260,7 @@ describe('TestSession', () => {
     it('should error if setup command fails', async () => {
       stubMethod(sandbox, shelljs, 'which').returns(true);
       const expectedCmd =
-        "sf org:create:scratch --description 'created by cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json";
+        "sf org:create:scratch --name 'cli-plugins-testkit' --json -y 1 -w 60 -f config/project-scratch-def.json";
       const execRv = 'Cannot foo before bar';
       const shellString = new ShellString(JSON.stringify(execRv));
       shellString.code = 1;


### PR DESCRIPTION
Adds a description to scratch orgs created by in the test session to allow get some usage numbers (scratch orgs created by NUTs on weekends, etc)

[skip-validate-pr]